### PR TITLE
Increase music staff size

### DIFF
--- a/app/(routes)/exam/page.tsx
+++ b/app/(routes)/exam/page.tsx
@@ -634,7 +634,7 @@ export default function ExamHomePage() {
             </Stack>
           </main>
         )}
-        {/* {viewState !== VIEW_STATES.SUBMIT_AND_EXIT &&
+        {viewState !== VIEW_STATES.SUBMIT_AND_EXIT &&
           viewState !== VIEW_STATES.START_TEST && (
             <Stack spacing={4}>
               <Button onClick={incrementViewState}>
@@ -649,7 +649,7 @@ export default function ExamHomePage() {
                 <Typography>{"Go to Progressions"}</Typography>
               </Button>
             </Stack>
-          )} */}
+          )}
       </Stack>
     </Box>
   );

--- a/app/components/ExamPages/KeySigIdentify.tsx
+++ b/app/components/ExamPages/KeySigIdentify.tsx
@@ -45,8 +45,8 @@ export default function KeySignaturesIdentification({
         sx={{ display: "flex", justifyContent: "center", alignItems: "center" }}
       >
         <Box
-          width={750}
-          height={540}
+          width={850}
+          height={500}
           bgcolor={"card.background"}
           borderRadius="var(--borderRadius)"
           boxShadow="var(--cardShadow)"

--- a/app/components/ExamPages/KeySigNotateTemplate.tsx
+++ b/app/components/ExamPages/KeySigNotateTemplate.tsx
@@ -59,8 +59,8 @@ export default function KeySignaturesNotation({
         sx={{ display: "flex", justifyContent: "center", alignItems: "center" }}
       >
         <Box
-          width={750}
-          height={540}
+          width={850}
+          height={500}
           bgcolor={"card.background"}
           borderRadius="var(--borderRadius)"
           boxShadow="var(--cardShadow)"

--- a/app/components/ExamPages/ScalesNotateTemplate.tsx
+++ b/app/components/ExamPages/ScalesNotateTemplate.tsx
@@ -58,8 +58,8 @@ export default function ScalesNotation({
       >
         <Stack spacing={4} p={2}>
           <Box
-            width={750}
-            height={540}
+            width={850}
+            height={500}
             bgcolor={"card.background"}
             borderRadius="var(--borderRadius)"
             boxShadow="var(--cardShadow)"

--- a/app/components/ExamPages/SeventhChordsNotateTemplate.tsx
+++ b/app/components/ExamPages/SeventhChordsNotateTemplate.tsx
@@ -74,8 +74,8 @@ export default function NotateSeventhChords({
       >
         <Stack spacing={4} p={2}>
           <Box
-            width={750}
-            height={540}
+            width={850}
+            height={500}
             bgcolor={"card.background"}
             borderRadius="var(--borderRadius)"
             margin={"auto"}

--- a/app/components/ExamPages/TriadsNotateTemplate.tsx
+++ b/app/components/ExamPages/TriadsNotateTemplate.tsx
@@ -74,8 +74,8 @@ export default function TriadsNotation({
       >
         <Stack spacing={4} p={2}>
           <Box
-            width={750}
-            height={540}
+            width={850}
+            height={500}
             bgcolor={"card.background"}
             borderRadius="var(--borderRadius)"
             margin={"auto"}

--- a/app/components/NotateChord.tsx
+++ b/app/components/NotateChord.tsx
@@ -49,6 +49,7 @@ const NotateChord = ({
 }) => {
   const rendererRef = useRef<InstanceType<typeof Renderer> | null>(null);
   const container = useRef<HTMLDivElement | null>(null);
+  const hasScaled = useRef<boolean>(false);
   const [staves, setStaves] = useState<StaveType[]>([]);
   const [chordInteractionState, dispatch] = useReducer(
     reducer,
@@ -96,6 +97,17 @@ const NotateChord = ({
         -4,
         true
       );
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!hasScaled.current && container.current) {
+      const svgElement = container.current.querySelector("svg");
+      if (svgElement) {
+        svgElement.style.transform = "scale(1.5)";
+        svgElement.style.transformOrigin = "0 0";
+        hasScaled.current = true;
+      }
     }
   }, []);
 
@@ -169,16 +181,23 @@ const NotateChord = ({
 
   return (
     <>
-      <div ref={container} onClick={handleClick} />
+      <div
+        ref={container}
+        onClick={handleClick}
+        style={{
+          overflow: "visible",
+          width: "705px",
+          height: "300px",
+        }}
+      />
       <SnackbarToast open={open} setOpen={setOpen} message={message} />
       <Container
         sx={{
           display: "grid",
           gridTemplateColumns: "1fr 1fr 1fr",
-          padding: 0,
+          paddingTop: 4,
           marginTop: 2,
         }}
-        disableGutters
       >
         {modifyChordsButtonGroup.map((button) => {
           return (

--- a/app/components/NotateKeySignature.tsx
+++ b/app/components/NotateKeySignature.tsx
@@ -98,11 +98,11 @@ const NotateKeySignature = ({ handleKeySig }: any) => {
     if (!hasScaled.current && container.current) {
       const svgElement = container.current.querySelector("svg");
       if (svgElement) {
-        svgElement.style.transform = "scale(1.2)";
+        svgElement.style.transform = "scale(1.5)";
         svgElement.style.transformOrigin = "0 0";
         // Adjust container size to accommodate scaled SVG
-        container.current.style.height = "240px"; // 200px * 1.2
-        container.current.style.width = "564px"; // 470px * 1.2
+        container.current.style.height = "300px";  // 200px * 1.5
+        container.current.style.width = "705px";   // 470px * 1.5
         hasScaled.current = true;
       }
     }
@@ -187,8 +187,8 @@ const NotateKeySignature = ({ handleKeySig }: any) => {
         onClick={handleClick}
         style={{
           overflow: "visible",
-          width: "564px",
-          height: "240px",
+          width: "705px",
+          height: "300px",
         }}
       />
 

--- a/app/components/NotateKeySignature.tsx
+++ b/app/components/NotateKeySignature.tsx
@@ -101,8 +101,8 @@ const NotateKeySignature = ({ handleKeySig }: any) => {
         svgElement.style.transform = "scale(1.2)";
         svgElement.style.transformOrigin = "0 0";
         // Adjust container size to accommodate scaled SVG
-        container.current.style.height = "240px";  // 200px * 1.2
-        container.current.style.width = "564px";   // 470px * 1.2
+        container.current.style.height = "240px"; // 200px * 1.2
+        container.current.style.width = "564px"; // 470px * 1.2
         hasScaled.current = true;
       }
     }
@@ -187,8 +187,8 @@ const NotateKeySignature = ({ handleKeySig }: any) => {
         onClick={handleClick}
         style={{
           overflow: "visible",
-          width: "564px", 
-          height: "240px", 
+          width: "564px",
+          height: "240px",
         }}
       />
 

--- a/app/components/NotateKeySignature.tsx
+++ b/app/components/NotateKeySignature.tsx
@@ -53,6 +53,7 @@ const NotateKeySignature = ({ handleKeySig }: any) => {
     NotesAndCoordinatesData[]
   >([initialNotesAndCoordsState]);
   const renderCount = useRef(0);
+  const hasScaled = useRef(false);
 
   const keySigButtonGroup = useMemo(
     () => buttonGroup(dispatch, state, modifyKeySigActionTypes),
@@ -72,15 +73,15 @@ const NotateKeySignature = ({ handleKeySig }: any) => {
         chosenClef,
         firstStaveWidth: 450,
         staves,
-        setStaves,
       }),
-    [staves]
+    [chosenClef]
   );
 
   useEffect(() => {
     initializeRenderer(rendererRef, container);
     const newStaves = renderStaves();
-    if (newStaves)
+    if (newStaves) {
+      setStaves(newStaves);
       calculateNotesAndCoordinates(
         chosenClef,
         setNotesAndCoordinates,
@@ -90,6 +91,21 @@ const NotateKeySignature = ({ handleKeySig }: any) => {
         1,
         0
       );
+    }
+  }, [chosenClef, renderStaves]);
+
+  useEffect(() => {
+    if (!hasScaled.current && container.current) {
+      const svgElement = container.current.querySelector("svg");
+      if (svgElement) {
+        svgElement.style.transform = "scale(1.2)";
+        svgElement.style.transformOrigin = "0 0";
+        // Adjust container size to accommodate scaled SVG
+        container.current.style.height = "240px";  // 200px * 1.2
+        container.current.style.width = "564px";   // 470px * 1.2
+        hasScaled.current = true;
+      }
+    }
   }, []);
 
   useEffect(() => {
@@ -166,7 +182,15 @@ const NotateKeySignature = ({ handleKeySig }: any) => {
 
   return (
     <>
-      <div ref={container} onClick={handleClick} />
+      <div
+        ref={container}
+        onClick={handleClick}
+        style={{
+          overflow: "visible",
+          width: "564px", 
+          height: "240px", 
+        }}
+      />
 
       <div>
         {keySigButtonGroup.map((button) => {

--- a/app/components/NotateKeySignature.tsx
+++ b/app/components/NotateKeySignature.tsx
@@ -110,8 +110,21 @@ const NotateKeySignature = ({ handleKeySig }: any) => {
   }, []);
 
   useEffect(() => {
-    renderStaves();
-    context && buildKeySignature(glyphs, 40, context, staves[0]);
+    if (context && staves.length > 0) {
+      // Clear and redraw without recreating the staves
+      context.clear();
+      staves[0].setContext(context).draw();
+      buildKeySignature(glyphs, 40, context, staves[0]);
+
+      // Re-apply scaling if needed
+      if (container.current) {
+        const svgElement = container.current.querySelector("svg");
+        if (svgElement) {
+          svgElement.style.transform = "scale(1.5)";
+          svgElement.style.transformOrigin = "0 0";
+        }
+      }
+    }
   }, [glyphs]);
 
   const clearKey = () => {

--- a/app/components/NotateKeySignature.tsx
+++ b/app/components/NotateKeySignature.tsx
@@ -33,6 +33,7 @@ import {
   StaveType,
 } from "../lib/typesAndInterfaces";
 import CustomButton from "./CustomButton";
+import { Container } from "@mui/material";
 
 const VF = VexFlow.Flow;
 const { Renderer } = VF;
@@ -191,8 +192,14 @@ const NotateKeySignature = ({ handleKeySig }: any) => {
           height: "300px",
         }}
       />
+      <SnackbarToast open={open} setOpen={setOpen} message={message} />
 
-      <div>
+      <Container
+        sx={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr 1fr 1fr",
+        }}
+      >
         {keySigButtonGroup.map((button) => {
           return (
             <CustomButton
@@ -205,8 +212,7 @@ const NotateKeySignature = ({ handleKeySig }: any) => {
           );
         })}
         <CustomButton onClick={clearKey}>Erase Key Signature</CustomButton>
-      </div>
-      <SnackbarToast open={open} setOpen={setOpen} message={message} />
+      </Container>
     </>
   );
 };

--- a/app/components/NotateKeySignature.tsx
+++ b/app/components/NotateKeySignature.tsx
@@ -101,8 +101,8 @@ const NotateKeySignature = ({ handleKeySig }: any) => {
         svgElement.style.transform = "scale(1.5)";
         svgElement.style.transformOrigin = "0 0";
         // Adjust container size to accommodate scaled SVG
-        container.current.style.height = "300px";  // 200px * 1.5
-        container.current.style.width = "705px";   // 470px * 1.5
+        container.current.style.height = "300px"; // 200px * 1.5
+        container.current.style.width = "705px"; // 470px * 1.5
         hasScaled.current = true;
       }
     }
@@ -133,7 +133,7 @@ const NotateKeySignature = ({ handleKeySig }: any) => {
 
   const handleClick = (e: React.MouseEvent) => {
     renderCount.current += 1;
-    console.log(`render count: ${renderCount.current}`);
+    // console.log(`render count: ${renderCount.current}`);
     const { userClickY, userClickX, topStaveYCoord, bottomStaveYCoord } =
       getUserClickInfo(e, container, staves[0]);
 

--- a/app/components/NotateScale.tsx
+++ b/app/components/NotateScale.tsx
@@ -49,6 +49,7 @@ const NotateScale = ({
 }) => {
   const rendererRef = useRef<InstanceType<typeof Renderer> | null>(null);
   const container = useRef<HTMLDivElement | null>(null);
+  const hasScaled = useRef<boolean>(false);
   const [staves, setStaves] = useState<StaveType[]>([]);
   const [scaleDataMatrix, setScaleDataMatrix] = useState<ScaleData[][]>([[]]);
   const [open, setOpen] = useState<boolean>(false);
@@ -91,6 +92,19 @@ const NotateScale = ({
         -4,
         true
       );
+  }, []);
+
+  useEffect(() => {
+    if (!hasScaled.current && container.current) {
+      const svgElement = container.current.querySelector("svg");
+      if (svgElement) {
+        svgElement.style.transform = "scale(1.5)";
+        svgElement.style.transformOrigin = "0 0";
+        container.current.style.height = "300px";
+        container.current.style.width = "705px";
+        hasScaled.current = true;
+      }
+    }
   }, []);
 
   useEffect(() => {
@@ -199,13 +213,21 @@ const NotateScale = ({
 
   return (
     <>
-      <div ref={container} onClick={handleClick} />
+      <div
+        ref={container}
+        onClick={handleClick}
+        style={{
+          overflow: "visible",
+          width: "705px",
+          height: "300px",
+        }}
+      />
       <SnackbarToast open={open} setOpen={setOpen} message={message} />
       <Container
         sx={{
           display: "grid",
-          gridTemplateColumns: "1fr 1fr 1fr",
-          padding: 0,
+          gridTemplateColumns: "1fr 1fr 1fr 1fr",
+          paddingTop: 4,
           marginTop: 2,
         }}
         disableGutters
@@ -223,9 +245,7 @@ const NotateScale = ({
             </CustomButton>
           );
         })}
-        <Button onClick={eraseMeasures} sx={{ m: 1 }}>
-          Erase Measure
-        </Button>
+        <CustomButton onClick={eraseMeasures}>Erase Measure</CustomButton>
       </Container>
     </>
   );

--- a/app/components/NotateScale.tsx
+++ b/app/components/NotateScale.tsx
@@ -230,7 +230,6 @@ const NotateScale = ({
           paddingTop: 4,
           marginTop: 2,
         }}
-        disableGutters
       >
         {modifyStaveNotesButtonGroup.map((button) => {
           return (

--- a/app/lib/getUserClickInfo.ts
+++ b/app/lib/getUserClickInfo.ts
@@ -9,22 +9,26 @@ const getUserClickInfo = (
   const rect = container && container.current?.getBoundingClientRect();
   const scale = 1.5;
   // Divide by scale since we need to map the click to the original coordinate space
-  const userClickY = rect ? parseFloat(((e.clientY - rect.top) / scale).toFixed(0)) : 0;
-  const userClickX = rect ? parseFloat(((e.clientX - rect.left) / scale).toFixed(0)) : 0;
+  const userClickY = rect
+    ? parseFloat(((e.clientY - rect.top) / scale).toFixed(0))
+    : 0;
+  const userClickX = rect
+    ? parseFloat(((e.clientX - rect.left) / scale).toFixed(0))
+    : 0;
   const topStaveYCoord = stave && stave.getYForTopText();
   const bottomStaveYCoord = (stave && stave.getYForBottomText()) || undefined;
 
-  console.log(`The maximum right click coordinate is 270, and the user click was
- ${userClickX}. The minimum left click is 36 and the user clicked ${userClickX}. The 
- minimum top click is 40 and the user clicked ${userClickY}. The maximum bottom
- click is 100 and user clicked ${userClickY}.`);
-  console.log("topStaveYCoord: ", topStaveYCoord);
-  console.log("bottomStaveYCoord: ", bottomStaveYCoord);
+  //   console.log(`The maximum right click coordinate is 270, and the user click was
+  //  ${userClickX}. The minimum left click is 36 and the user clicked ${userClickX}. The
+  //  minimum top click is 40 and the user clicked ${userClickY}. The maximum bottom
+  //  click is 100 and user clicked ${userClickY}.`);
+  //   console.log("topStaveYCoord: ", topStaveYCoord);
+  //   console.log("bottomStaveYCoord: ", bottomStaveYCoord);
 
   return {
     rect,
-    userClickY: Number(userClickY),  // Convert back to number since we used toFixed
-    userClickX: Number(userClickX),  // Convert back to number since we used toFixed
+    userClickY: Number(userClickY), // Convert back to number since we used toFixed
+    userClickX: Number(userClickX), // Convert back to number since we used toFixed
     topStaveYCoord,
     bottomStaveYCoord,
   };

--- a/app/lib/getUserClickInfo.ts
+++ b/app/lib/getUserClickInfo.ts
@@ -7,7 +7,7 @@ const getUserClickInfo = (
   stave: StaveType
 ): any => {
   const rect = container && container.current?.getBoundingClientRect();
-  const scale = 1.2;
+  const scale = 1.5;
   // Divide by scale since we need to map the click to the original coordinate space
   const userClickY = rect ? parseFloat(((e.clientY - rect.top) / scale).toFixed(0)) : 0;
   const userClickX = rect ? parseFloat(((e.clientX - rect.left) / scale).toFixed(0)) : 0;

--- a/app/lib/getUserClickInfo.ts
+++ b/app/lib/getUserClickInfo.ts
@@ -7,11 +7,12 @@ const getUserClickInfo = (
   stave: StaveType
 ): any => {
   const rect = container && container.current?.getBoundingClientRect();
-  const userClickY = rect ? parseFloat((e.clientY - rect.top).toFixed(0)) : 0;
-  const userClickX = rect ? parseFloat((e.clientX - rect.left).toFixed(0)) : 0;
+  const scale = 1.2;
+  // Divide by scale since we need to map the click to the original coordinate space
+  const userClickY = rect ? parseFloat(((e.clientY - rect.top) / scale).toFixed(0)) : 0;
+  const userClickX = rect ? parseFloat(((e.clientX - rect.left) / scale).toFixed(0)) : 0;
   const topStaveYCoord = stave && stave.getYForTopText();
   const bottomStaveYCoord = (stave && stave.getYForBottomText()) || undefined;
-  //need to figure out how to NOT hard code 33
 
   console.log(`The maximum right click coordinate is 270, and the user click was
  ${userClickX}. The minimum left click is 36 and the user clicked ${userClickX}. The 
@@ -22,8 +23,8 @@ const getUserClickInfo = (
 
   return {
     rect,
-    userClickY,
-    userClickX,
+    userClickY: Number(userClickY),  // Convert back to number since we used toFixed
+    userClickX: Number(userClickX),  // Convert back to number since we used toFixed
     topStaveYCoord,
     bottomStaveYCoord,
   };

--- a/app/lib/isClickWithinStaveBounds.ts
+++ b/app/lib/isClickWithinStaveBounds.ts
@@ -14,13 +14,13 @@ const isClickWithinStaveBounds = (
   const minLeftClick = measureWidth * 0.08;
   const minTopClick = topStaveMaxYClick;
   const maxBottomClick = bottomStaveMaxYClick;
-  console.log(
-    `measure width: ${measureWidth}\n`,
-    `max right click: ${maxRightClick}\n`,
-    `min left click: ${minLeftClick}\n`,
-    `min top click: ${minTopClick}\n`,
-    `max bottom click: ${maxBottomClick}`
-  );
+  // console.log(
+  //   `measure width: ${measureWidth}\n`,
+  //   `max right click: ${maxRightClick}\n`,
+  //   `min left click: ${minLeftClick}\n`,
+  //   `min top click: ${minTopClick}\n`,
+  //   `max bottom click: ${maxBottomClick}`
+  // );
 
   if (
     userClickX < minLeftClick ||

--- a/app/lib/modifyChords.ts
+++ b/app/lib/modifyChords.ts
@@ -54,7 +54,7 @@ const appendAccidentalToNote = (accidental: string, note: string) => {
     (accidental === "#" && noteBase.length > 1 && noteBase.endsWith("b")) ||
     (accidental === "b" && noteBase.endsWith("#"))
   ) {
-    console.log("Cannot add contradictory accidentals to the same note.");
+    // console.log("Cannot add contradictory accidentals to the same note.");
     return note;
   }
   if (noteBase.length < 3) {

--- a/app/lib/modifyKeySignature.ts
+++ b/app/lib/modifyKeySignature.ts
@@ -39,8 +39,8 @@ export const addGlyphs = (
     glyph: keySigState.isSharpActive
       ? "accidentalSharp"
       : keySigState.isFlatActive
-      ? "accidentalFlat"
-      : "",
+        ? "accidentalFlat"
+        : "",
   };
   for (const glyph of glyphs) {
     if (glyph.yPosition === newState.yPosition) return;
@@ -74,7 +74,7 @@ export const deleteAccidentalFromKeySigArray = (
   keySigArray: string[],
   setKeySigState: (newState: React.SetStateAction<string[]>) => void
 ) => {
-  console.log("foundNoteData: ", foundNoteData.note);
+  // console.log("foundNoteData: ", foundNoteData.note);
   const noteBase = parseNote(foundNoteData.note).noteBase;
   const newKeySig = [...keySigArray];
   if (newKeySig.includes(noteBase)) {

--- a/app/lib/modifyNotesAndCoordinates.ts
+++ b/app/lib/modifyNotesAndCoordinates.ts
@@ -15,7 +15,7 @@ export const appendAccidentalToNote = (accidental: string, note: string) => {
     (accidental === "#" && noteBase.length > 1 && noteBase.endsWith("b")) ||
     (accidental === "b" && noteBase.endsWith("#"))
   ) {
-    console.log("Cannot add contradictory accidentals to the same note.");
+    // console.log("Cannot add contradictory accidentals to the same note.");
     return note;
   }
 
@@ -23,7 +23,7 @@ export const appendAccidentalToNote = (accidental: string, note: string) => {
     return `${noteBase}${accidental}/${octave}`;
   }
   if (noteBase.length > 3) {
-    console.log("Cannot add more than 2 accidentals to a note.");
+    // console.log("Cannot add more than 2 accidentals to a note.");
   }
   return `${noteBase}/${octave}`;
 };

--- a/app/lib/savePDF.ts
+++ b/app/lib/savePDF.ts
@@ -29,11 +29,11 @@ export const savePDF = async (
 
     // awaiting Promise
     await uploadBytes(storageRef, pdfBlob);
-    console.log("PDF uploaded successfully");
+    // console.log("PDF uploaded successfully");
 
     // awaiting Promise
     const url = await getDownloadURL(storageRef);
-    console.log("URL: ", url);
+    // console.log("URL: ", url);
 
     setCurrentUserData({ ...currentUserData, bluesUrl: url });
   } catch (error) {

--- a/app/lib/setUpRendererAndDrawChords.ts
+++ b/app/lib/setUpRendererAndDrawChords.ts
@@ -26,7 +26,7 @@ export const setupRendererAndDrawChords = (
   const renderer = rendererRef?.current;
   renderer?.resize(rendererWidth, rendererHeight);
   const context = renderer && renderer.getContext();
-  context?.setFont(font, fontSize);
+  context?.setFont(font, fontSize * 1.5);
   context?.clear();
   let newStaves;
   if (context && rendererRef) {

--- a/app/lib/setUpRendererAndDrawStaves.ts
+++ b/app/lib/setUpRendererAndDrawStaves.ts
@@ -20,7 +20,7 @@ export const setupRendererAndDrawStaves = (
   const renderer = rendererRef?.current;
   renderer?.resize(rendererWidth, rendererHeight);
   const context = renderer && renderer.getContext();
-  context?.setFont(font, fontSize * 1.2);
+  context?.setFont(font, fontSize * 1.5);
   context?.clear();
   let newStaves;
   if (context && rendererRef) {

--- a/app/lib/setUpRendererAndDrawStaves.ts
+++ b/app/lib/setUpRendererAndDrawStaves.ts
@@ -16,12 +16,11 @@ export const setupRendererAndDrawStaves = (
     chosenClef,
     firstStaveWidth,
     keySig,
-    setStaves,
   } = params;
   const renderer = rendererRef?.current;
   renderer?.resize(rendererWidth, rendererHeight);
   const context = renderer && renderer.getContext();
-  context?.setFont(font, fontSize);
+  context?.setFont(font, fontSize * 1.2);
   context?.clear();
   let newStaves;
   if (context && rendererRef) {
@@ -35,7 +34,6 @@ export const setupRendererAndDrawStaves = (
       chosenClef,
       keySig,
     });
-    setStaves(newStaves);
   }
   return newStaves;
 };

--- a/app/lib/setupRendererAndDrawNotes.ts
+++ b/app/lib/setupRendererAndDrawNotes.ts
@@ -26,7 +26,7 @@ export const setupRendererAndDrawNotes = (
   const renderer = rendererRef?.current;
   renderer?.resize(rendererWidth, rendererHeight);
   const context = renderer && renderer.getContext();
-  context?.setFont(font, fontSize);
+  context?.setFont(font, fontSize * 1.5);
   context?.clear();
   let newStaves;
   if (context && rendererRef) {

--- a/app/lib/typesAndInterfaces.ts
+++ b/app/lib/typesAndInterfaces.ts
@@ -200,7 +200,7 @@ export interface RenderStaves {
   keySig?: string;
   firstStaveWidth: number;
   regularStaveWidth?: number | null;
-  setStaves: SetStaves;
+  setStaves?: SetStaves;
   staves: BlankStaves;
 }
 export interface RenderStavesAndChordParams {

--- a/firebase/authAPI.ts
+++ b/firebase/authAPI.ts
@@ -40,7 +40,7 @@ export async function completeSignIn(link: string) {
       const result = await signInWithEmailLink(auth, emailForSignIn, link);
       window.localStorage.removeItem("emailForSignIn");
       if (result.user) {
-        console.log("Sign in successful! CurrentUser:", result.user);
+        // console.log("Sign in successful! CurrentUser:", result.user);
         return true;
       }
     }
@@ -100,10 +100,10 @@ export async function signIn(email: string, password: string) {
       console.error("signInWithEmailAndPassword error:", err);
     });
     if (auth.currentUser !== null) {
-      console.log(
-        "Sign in successfull! CurrentUser:",
-        auth.currentUser.displayName
-      );
+      // console.log(
+      //   "Sign in successfull! CurrentUser:",
+      //   auth.currentUser.displayName
+      // );
       return true;
     }
   } catch (err) {


### PR DESCRIPTION
- Scaled the size of the music staff and notes via svg transform scale to 1.5 with new calculations in getUserClickInfo, NotateKeySignature, NotateScale, setUpRendererAndDrawStaves, setupRendererAndDrawNotes, NotateChord, SeventhChord, and  TriadsNotateTemplate
- Fixed Typescript error - make interface RenderStaves setStaves optional
- Commented out console.logs
- Changed button layout on Notate scales and change Erase Measure to a CustomButton.
- Refactored the box sizes and buttons for better layout
- Matched the Container element style to NotateScale
- Modified useEffect for glyphs to clear context and redraw existing staff