### PR TITLE
Refactor of NotateChord, NotateKeySignature, NotateScale logic

### DIFF
--- a/app/(routes)/exam/page.tsx
+++ b/app/(routes)/exam/page.tsx
@@ -43,7 +43,6 @@ import {
 import { Box, Button, Container, Grid, Stack, Typography } from "@mui/material";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
-import { useButtonStates } from "../../lib/useButtonStates";
 
 const VIEW_STATES = {
   START_TEST: 0,
@@ -100,7 +99,6 @@ export default function ExamHomePage() {
   const [open, setOpen] = useState<boolean>(false);
   const [level, setLevel] = useState<Level>("select-here");
   const { chosenClef: clef, setChosenClef: setClef } = useClef();
-  const { states, setters, clearAllStates } = useButtonStates();
 
   useEffect(() => {
     const fetchSnapshot = async () => {
@@ -109,7 +107,6 @@ export default function ExamHomePage() {
         if (error) {
           console.error(message);
         } else if (res) {
-          console.log(success);
           setCurrentUserData((prevCurrentUserData) => ({
             ...prevCurrentUserData,
             ...res[0],
@@ -145,7 +142,6 @@ export default function ExamHomePage() {
       currentUserData.scales5,
       currentUserData.scales6,
     ];
-    console.log("userScales from updateAnswers on Exam page:", userScales);
     const userTriads = [
       currentUserData.triads1,
       currentUserData.triads2,

--- a/app/components/ExamPages/ScalesNotateTemplate.tsx
+++ b/app/components/ExamPages/ScalesNotateTemplate.tsx
@@ -7,7 +7,6 @@ import { useState } from "react";
 import CardFooter from "../CardFooter";
 import NotateScale from "../NotateScale";
 import TutorialModal from "../TutorialModal";
-import { useButtonStates } from "../../lib/useButtonStates";
 
 export default function ScalesNotation({
   currentUserData,
@@ -16,7 +15,6 @@ export default function ScalesNotation({
   page,
 }: UserDataProps) {
   const [scales, setScales] = useState<string[]>([]);
-  const { states, setters, clearAllStates } = useButtonStates();
 
   const scalesPropName = `scales${page - 5}`;
 

--- a/app/components/NotateScale.tsx
+++ b/app/components/NotateScale.tsx
@@ -226,8 +226,7 @@ const NotateScale = ({
         errorMessages
       );
 
-      // Update state with the new values
-      // CRITICAL FIX: We must use setState with a function to ensure we're working with
+      // We must use setState with a function to ensure we're working with
       // the latest state and properly merge the new values
       setScaleDataMatrix((prevState) => {
         console.log(

--- a/app/components/NotateScale.tsx
+++ b/app/components/NotateScale.tsx
@@ -47,8 +47,10 @@ const NotateScale = ({
   const { chosenClef } = useClef();
 
   // Use our new renderer hook for VexFlow initialization
-  const renderFunctionRef = useRef<(() => StaveType[] | undefined) | null>(null);
-  
+  const renderFunctionRef = useRef<(() => StaveType[] | undefined) | null>(
+    null
+  );
+
   const { rendererRef } = useNotationRenderer({
     containerRef: container,
     renderFunction: () => {
@@ -58,12 +60,12 @@ const NotateScale = ({
       return undefined;
     },
     width: 470,
-    height: 200
+    height: 200,
   });
-  
+
   // Setup the actual render function now that rendererRef is initialized
   renderFunctionRef.current = useCallback(
-    (): StaveType[] | undefined => 
+    (): StaveType[] | undefined =>
       setupRendererAndDrawNotes({
         rendererRef,
         ...staveData,
@@ -81,7 +83,7 @@ const NotateScale = ({
     staves,
     notesAndCoordinates,
     setOpen,
-    setMessage
+    setMessage,
   });
 
   // Initial load
@@ -139,27 +141,31 @@ const NotateScale = ({
   // Enhanced click handler with better debugging and error prevention
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
-      console.log('Click detected in NotateScale');
-      console.log('CURRENT BUTTON STATES at click time:', {
+      console.log("Click detected in NotateScale");
+      console.log("CURRENT BUTTON STATES at click time:", {
         isSharpActive: states.isSharpActive,
         isFlatActive: states.isFlatActive,
         isEnterNoteActive: states.isEnterNoteActive,
-        isEraseNoteActive: states.isEraseNoteActive
+        isEraseNoteActive: states.isEraseNoteActive,
       });
-      
+
       // Get click information
       const clickInfo = getClickInfo(e);
       if (!clickInfo) {
-        console.log('No valid click info found');
+        console.log("No valid click info found");
         return;
       }
-      
+
       const { userClickX, userClickY, foundNoteData } = clickInfo;
-      console.log('Click info:', { userClickX, userClickY, note: foundNoteData.note });
+      console.log("Click info:", {
+        userClickX,
+        userClickY,
+        note: foundNoteData.note,
+      });
 
       // Find which bar was clicked
       const barIndex = findBarIndex(staves, userClickX);
-      console.log('Bar index:', barIndex);
+      console.log("Bar index:", barIndex);
 
       // Create a safe deep clone that properly handles VexFlow objects
       // We need to specially handle staveNote objects to avoid circular references
@@ -171,53 +177,61 @@ const NotateScale = ({
           // The real StaveNote will be recreated in HandleScaleInteraction
           newStaveNote = new VexFlow.Flow.StaveNote({
             keys: [...note.keys],
-            duration: note.duration || 'q',
-            clef: chosenClef
+            duration: note.duration || "q",
+            clef: chosenClef,
           });
         }
-        
+
         // Return a properly typed ScaleData object
         return {
           keys: note.keys ? [...note.keys] : [],
-          duration: note.duration || 'q',
+          duration: note.duration || "q",
           exactX: note.exactX,
           userClickY: note.userClickY,
-          staveNote: newStaveNote // Add the staveNote property to satisfy TypeScript
+          staveNote: newStaveNote, // Add the staveNote property to satisfy TypeScript
         };
       };
 
       // Create clean copies without circular references
-      let scaleDataMatrixCopy = scaleDataMatrix.map(bar => 
-        bar.map(note => safeCloneNote(note))
+      let scaleDataMatrixCopy = scaleDataMatrix.map((bar) =>
+        bar.map((note) => safeCloneNote(note))
       );
-      let notesAndCoordinatesCopy = notesAndCoordinates.map(note => ({...note}));
+      let notesAndCoordinatesCopy = notesAndCoordinates.map((note) => ({
+        ...note,
+      }));
 
       // Extract the specific bar data for the clicked bar
       // Make sure it exists to prevent errors
       if (!scaleDataMatrixCopy[barIndex]) {
-        console.error('Invalid bar index:', barIndex);
+        console.error("Invalid bar index:", barIndex);
         return;
       }
 
       // Get bar of scale data with proper deep copy
       const barOfScaleData = scaleDataMatrixCopy[barIndex];
-      
-      console.log('DEBUGGING - Current button states:', {
+
+      console.log("DEBUGGING - Current button states:", {
         isSharpActive: states.isSharpActive,
         isFlatActive: states.isFlatActive,
-        isEnterNoteActive: states.isEnterNoteActive
+        isEnterNoteActive: states.isEnterNoteActive,
       });
-      
+
       // Debug exact location of click vs existing notes
-      console.log('DEBUGGING - Click position:', { x: userClickX, y: userClickY });
-      
+      console.log("DEBUGGING - Click position:", {
+        x: userClickX,
+        y: userClickY,
+      });
+
       // Log exact positions of existing notes to debug distance calculation
-      console.log('DEBUGGING - Existing notes with positions:', 
+      console.log(
+        "DEBUGGING - Existing notes with positions:",
         barOfScaleData.map((note: ScaleData, index: number) => ({
           index,
           key: note.keys?.[0],
           x: note.exactX,
-          distanceFromClick: note.exactX ? Math.abs(note.exactX - userClickX) : 'N/A'
+          distanceFromClick: note.exactX
+            ? Math.abs(note.exactX - userClickX)
+            : "N/A",
         }))
       );
 
@@ -228,15 +242,19 @@ const NotateScale = ({
       // Make sure we're working with the ACTUAL current positions of notes
       // This is critical for the first click after adding a new note
       if (isAccidentalMode && scaleDataMatrix[0].length > 0) {
-        console.log('ACCIDENTAL MODE DETECTED - Ensuring note positions are up to date');
-        
+        console.log(
+          "ACCIDENTAL MODE DETECTED - Ensuring note positions are up to date"
+        );
+
         // Make sure the bar data has the correct x-coordinates from the most recently rendered state
         for (let i = 0; i < barOfScaleData.length; i++) {
           const originalNote = scaleDataMatrix[barIndex]?.[i];
           if (originalNote && originalNote.exactX !== undefined) {
             // Use the most current exactX value from the rendered note
             barOfScaleData[i].exactX = originalNote.exactX;
-            console.log(`Updated note ${i} position to exact ${originalNote.exactX}px`);
+            console.log(
+              `Updated note ${i} position to exact ${originalNote.exactX}px`
+            );
           }
         }
       }
@@ -260,46 +278,56 @@ const NotateScale = ({
         errorMessages
       );
 
-      console.log('After handling interaction:');
-      
+      console.log("After handling interaction:");
+
       // Safely log without triggering circular reference errors
       try {
-        const noteKeys = newScaleDataMatrix[0].map((note: ScaleData) => note.keys?.[0] || 'unknown');
-        console.log('- New notes in bar:', noteKeys);
+        const noteKeys = newScaleDataMatrix[0].map(
+          (note: ScaleData) => note.keys?.[0] || "unknown"
+        );
+        console.log("- New notes in bar:", noteKeys);
       } catch (error) {
-        console.error('Error logging note data:', error);
+        console.error("Error logging note data:", error);
       }
 
       // Update state with the new values
       // CRITICAL FIX: We must use setState with a function to ensure we're working with
       // the latest state and properly merge the new values
       setScaleDataMatrix((prevState) => {
-        console.log('STATE UPDATE: Updating scale data matrix');
-        console.log('- Previous state had:', prevState.map(bar => 
-          `${bar.length} notes (${bar.map(n => n?.keys?.[0] || 'unknown').join(', ')})`
-        ));
-        console.log('- New state has:', newScaleDataMatrix.map(bar => 
-          `${bar.length} notes (${bar.map(n => n?.keys?.[0] || 'unknown').join(', ')})`
-        ));
-        
+        console.log("STATE UPDATE: Updating scale data matrix");
+        console.log(
+          "- Previous state had:",
+          prevState.map(
+            (bar) =>
+              `${bar.length} notes (${bar.map((n) => n?.keys?.[0] || "unknown").join(", ")})`
+          )
+        );
+        console.log(
+          "- New state has:",
+          newScaleDataMatrix.map(
+            (bar) =>
+              `${bar.length} notes (${bar.map((n) => n?.keys?.[0] || "unknown").join(", ")})`
+          )
+        );
+
         // This ensures we properly replace the state with the new complete state
         return [...newScaleDataMatrix];
       });
-      
+
       // Update the note coordinates similarly using function form
       setNotesAndCoordinates((prevCoords) => {
-        console.log('STATE UPDATE: Updating note coordinates');
+        console.log("STATE UPDATE: Updating note coordinates");
         return [...newNotesAndCoordinates];
       });
 
       // Update the scales display - safely extract just the key strings
       try {
         const scaleStrings = newScaleDataMatrix[0].map((note: ScaleData) => {
-          return Array.isArray(note.keys) ? note.keys.join(", ") : '';
+          return Array.isArray(note.keys) ? note.keys.join(", ") : "";
         });
         setScales(scaleStrings);
       } catch (error) {
-        console.error('Error updating scale display:', error);
+        console.error("Error updating scale display:", error);
       }
     },
     [scaleDataMatrix, notesAndCoordinates, staves, chosenClef, states]
@@ -314,100 +342,100 @@ const NotateScale = ({
         setOpen={setOpen}
         message={message}
       >
-      <Container
-        sx={{
-          display: "grid",
-          gridTemplateColumns: "1fr 1fr 1fr 1fr",
-          paddingTop: 4,
-          marginTop: 2,
-        }}
-      >
-        <CustomButton
-          onClick={() => {
-            clearAllStates();
-            setters.setIsEnterNoteActive(true);
+        <Container
+          sx={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr 1fr 1fr",
+            paddingTop: 4,
+            marginTop: 2,
           }}
-          active={states.isEnterNoteActive}
         >
-          Enter Note
-        </CustomButton>
-        <CustomButton
-          onClick={() => {
-            clearAllStates();
-            setters.setIsEraseNoteActive(true);
-          }}
-          active={states.isEraseNoteActive}
-        >
-          Erase Note
-        </CustomButton>
-        <CustomButton
-          onClick={() => {
-            clearAllStates();
-            setters.setIsChangeNoteActive(true);
-          }}
-          active={states.isChangeNoteActive}
-        >
-          Change Note
-        </CustomButton>
-        <CustomButton
-          onClick={() => {
-            console.log('\n\n ADD SHARP BUTTON CLICKED');
-            console.log('Button states before:', states);
-            // First clear all states
-            clearAllStates();
-            // Then update the sharp button state
-            setters.setIsSharpActive(true);
-            // Force a render to ensure state is updated before next click
-            renderFunctionRef.current?.();
-            // Log immediately and confirm after a small delay to verify state is updated
-            console.log('Sharp button should now be active');
-            setTimeout(() => {
-              console.log('Button states confirmation after update:', {
-                isSharpActive: states.isSharpActive,
-                isFlatActive: states.isFlatActive,
-                isEnterNoteActive: states.isEnterNoteActive
-              });
-            }, 100); // Slightly longer delay to ensure state updates
-          }}
-          active={states.isSharpActive}
-        >
-          Add Sharp
-        </CustomButton>
-        <CustomButton
-          onClick={() => {
-            console.log('\n\n ADD FLAT BUTTON CLICKED');
-            console.log('Button states before:', states);
-            // First clear all states
-            clearAllStates();
-            // Then update the flat button state
-            setters.setIsFlatActive(true);
-            // Force a render to ensure state is updated before next click
-            renderFunctionRef.current?.();
-            // Log immediately and confirm after a small delay to verify state is updated
-            console.log('Flat button should now be active');
-            setTimeout(() => {
-              console.log('Button states confirmation after update:', {
-                isSharpActive: states.isSharpActive,
-                isFlatActive: states.isFlatActive,
-                isEnterNoteActive: states.isEnterNoteActive
-              });
-            }, 100); // Slightly longer delay to ensure state updates
-          }}
-          active={states.isFlatActive}
-        >
-          Add Flat
-        </CustomButton>
-        <CustomButton
-          onClick={() => {
-            clearAllStates();
-            setters.setIsEraseAccidentalActive(true);
-          }}
-          active={states.isEraseAccidentalActive}
-        >
-          Erase Accidental
-        </CustomButton>
-        <Button onClick={eraseMeasures}>Clear All</Button>
-      </Container>
+          <CustomButton
+            onClick={() => {
+              clearAllStates();
+              setters.setIsEnterNoteActive(true);
+            }}
+            active={states.isEnterNoteActive}
+          >
+            Enter Note
+          </CustomButton>
+          <CustomButton
+            onClick={() => {
+              clearAllStates();
+              setters.setIsEraseNoteActive(true);
+            }}
+            active={states.isEraseNoteActive}
+          >
+            Erase Note
+          </CustomButton>
+          <CustomButton
+            onClick={() => {
+              clearAllStates();
+              setters.setIsChangeNoteActive(true);
+            }}
+            active={states.isChangeNoteActive}
+          >
+            Change Note
+          </CustomButton>
+          <CustomButton
+            onClick={() => {
+              console.log("\n\n ADD SHARP BUTTON CLICKED");
+              console.log("Button states before:", states);
+              // First clear all states
+              clearAllStates();
+              // Then update the sharp button state
+              setters.setIsSharpActive(true);
+              // Force a render to ensure state is updated before next click
+              renderFunctionRef.current?.();
+              // Log immediately and confirm after a small delay to verify state is updated
+              console.log("Sharp button should now be active");
+              setTimeout(() => {
+                console.log("Button states confirmation after update:", {
+                  isSharpActive: states.isSharpActive,
+                  isFlatActive: states.isFlatActive,
+                  isEnterNoteActive: states.isEnterNoteActive,
+                });
+              }, 100); // Slightly longer delay to ensure state updates
+            }}
+            active={states.isSharpActive}
+          >
+            Add Sharp
+          </CustomButton>
+          <CustomButton
+            onClick={() => {
+              console.log("\n\n ADD FLAT BUTTON CLICKED");
+              console.log("Button states before:", states);
+              // First clear all states
+              clearAllStates();
+              // Then update the flat button state
+              setters.setIsFlatActive(true);
+              // Force a render to ensure state is updated before next click
+              renderFunctionRef.current?.();
+              // Log immediately and confirm after a small delay to verify state is updated
+              console.log("Flat button should now be active");
+              setTimeout(() => {
+                console.log("Button states confirmation after update:", {
+                  isSharpActive: states.isSharpActive,
+                  isFlatActive: states.isFlatActive,
+                  isEnterNoteActive: states.isEnterNoteActive,
+                });
+              }, 100); // Slightly longer delay to ensure state updates
+            }}
+            active={states.isFlatActive}
+          >
+            Add Flat
+          </CustomButton>
+          <CustomButton
+            onClick={() => {
+              clearAllStates();
+              setters.setIsEraseAccidentalActive(true);
+            }}
+            active={states.isEraseAccidentalActive}
+          >
+            Erase Accidental
+          </CustomButton>
+          <Button onClick={eraseMeasures}>Clear All</Button>
+        </Container>
       </NotationContainer>
     </>
   );

--- a/app/components/NotateScale.tsx
+++ b/app/components/NotateScale.tsx
@@ -370,15 +370,6 @@ const NotateScale = ({
           </CustomButton>
           <CustomButton
             onClick={() => {
-              clearAllStates();
-              setters.setIsChangeNoteActive(true);
-            }}
-            active={states.isChangeNoteActive}
-          >
-            Change Note
-          </CustomButton>
-          <CustomButton
-            onClick={() => {
               console.log("\n\n ADD SHARP BUTTON CLICKED");
               console.log("Button states before:", states);
               // First clear all states

--- a/app/components/NotateScale.tsx
+++ b/app/components/NotateScale.tsx
@@ -138,34 +138,18 @@ const NotateScale = ({
     }
   };
 
-  // Enhanced click handler with better debugging and error prevention
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
-      console.log("Click detected in NotateScale");
-      console.log("CURRENT BUTTON STATES at click time:", {
-        isSharpActive: states.isSharpActive,
-        isFlatActive: states.isFlatActive,
-        isEnterNoteActive: states.isEnterNoteActive,
-        isEraseNoteActive: states.isEraseNoteActive,
-      });
-
-      // Get click information
       const clickInfo = getClickInfo(e);
       if (!clickInfo) {
-        console.log("No valid click info found");
+        console.error("No valid click info found");
         return;
       }
 
       const { userClickX, userClickY, foundNoteData } = clickInfo;
-      console.log("Click info:", {
-        userClickX,
-        userClickY,
-        note: foundNoteData.note,
-      });
 
       // Find which bar was clicked
       const barIndex = findBarIndex(staves, userClickX);
-      console.log("Bar index:", barIndex);
 
       // Create a safe deep clone that properly handles VexFlow objects
       // We need to specially handle staveNote objects to avoid circular references
@@ -210,51 +194,15 @@ const NotateScale = ({
       // Get bar of scale data with proper deep copy
       const barOfScaleData = scaleDataMatrixCopy[barIndex];
 
-      console.log("DEBUGGING - Current button states:", {
-        isSharpActive: states.isSharpActive,
-        isFlatActive: states.isFlatActive,
-        isEnterNoteActive: states.isEnterNoteActive,
-      });
-
-      // Debug exact location of click vs existing notes
-      console.log("DEBUGGING - Click position:", {
-        x: userClickX,
-        y: userClickY,
-      });
-
-      // Log exact positions of existing notes to debug distance calculation
-      console.log(
-        "DEBUGGING - Existing notes with positions:",
-        barOfScaleData.map((note: ScaleData, index: number) => ({
-          index,
-          key: note.keys?.[0],
-          x: note.exactX,
-          distanceFromClick: note.exactX
-            ? Math.abs(note.exactX - userClickX)
-            : "N/A",
-        }))
-      );
-
-      // IMPORTANT CHECK: For the first click after adding a note, make a special adjustment
-      // This ensures note positions are correctly synchronized when working with accidentals
       const isAccidentalMode = states.isSharpActive || states.isFlatActive;
 
-      // Make sure we're working with the ACTUAL current positions of notes
-      // This is critical for the first click after adding a new note
       if (isAccidentalMode && scaleDataMatrix[0].length > 0) {
-        console.log(
-          "ACCIDENTAL MODE DETECTED - Ensuring note positions are up to date"
-        );
-
         // Make sure the bar data has the correct x-coordinates from the most recently rendered state
         for (let i = 0; i < barOfScaleData.length; i++) {
           const originalNote = scaleDataMatrix[barIndex]?.[i];
           if (originalNote && originalNote.exactX !== undefined) {
             // Use the most current exactX value from the rendered note
             barOfScaleData[i].exactX = originalNote.exactX;
-            console.log(
-              `Updated note ${i} position to exact ${originalNote.exactX}px`
-            );
           }
         }
       }
@@ -278,23 +226,10 @@ const NotateScale = ({
         errorMessages
       );
 
-      console.log("After handling interaction:");
-
-      // Safely log without triggering circular reference errors
-      try {
-        const noteKeys = newScaleDataMatrix[0].map(
-          (note: ScaleData) => note.keys?.[0] || "unknown"
-        );
-        console.log("- New notes in bar:", noteKeys);
-      } catch (error) {
-        console.error("Error logging note data:", error);
-      }
-
       // Update state with the new values
       // CRITICAL FIX: We must use setState with a function to ensure we're working with
       // the latest state and properly merge the new values
       setScaleDataMatrix((prevState) => {
-        console.log("STATE UPDATE: Updating scale data matrix");
         console.log(
           "- Previous state had:",
           prevState.map(
@@ -314,9 +249,7 @@ const NotateScale = ({
         return [...newScaleDataMatrix];
       });
 
-      // Update the note coordinates similarly using function form
       setNotesAndCoordinates((prevCoords) => {
-        console.log("STATE UPDATE: Updating note coordinates");
         return [...newNotesAndCoordinates];
       });
 
@@ -370,16 +303,10 @@ const NotateScale = ({
           </CustomButton>
           <CustomButton
             onClick={() => {
-              console.log("\n\n ADD SHARP BUTTON CLICKED");
-              console.log("Button states before:", states);
-              // First clear all states
               clearAllStates();
-              // Then update the sharp button state
               setters.setIsSharpActive(true);
               // Force a render to ensure state is updated before next click
               renderFunctionRef.current?.();
-              // Log immediately and confirm after a small delay to verify state is updated
-              console.log("Sharp button should now be active");
               setTimeout(() => {
                 console.log("Button states confirmation after update:", {
                   isSharpActive: states.isSharpActive,
@@ -394,23 +321,16 @@ const NotateScale = ({
           </CustomButton>
           <CustomButton
             onClick={() => {
-              console.log("\n\n ADD FLAT BUTTON CLICKED");
-              console.log("Button states before:", states);
-              // First clear all states
               clearAllStates();
-              // Then update the flat button state
               setters.setIsFlatActive(true);
-              // Force a render to ensure state is updated before next click
               renderFunctionRef.current?.();
-              // Log immediately and confirm after a small delay to verify state is updated
-              console.log("Flat button should now be active");
               setTimeout(() => {
                 console.log("Button states confirmation after update:", {
                   isSharpActive: states.isSharpActive,
                   isFlatActive: states.isFlatActive,
                   isEnterNoteActive: states.isEnterNoteActive,
                 });
-              }, 100); // Slightly longer delay to ensure state updates
+              }, 100);
             }}
             active={states.isFlatActive}
           >

--- a/app/components/NotationContainer.tsx
+++ b/app/components/NotationContainer.tsx
@@ -1,0 +1,42 @@
+import React, { RefObject, ReactNode } from 'react';
+import SnackbarToast from './SnackbarToast';
+
+type NotationContainerProps = {
+  containerRef: RefObject<HTMLDivElement>;
+  onClick?: (e: React.MouseEvent) => void;
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  message: string;
+  children?: ReactNode;
+  width?: string;
+  height?: string;
+};
+
+const NotationContainer = ({
+  containerRef,
+  onClick,
+  open,
+  setOpen,
+  message,
+  children,
+  width = '705px',
+  height = '300px',
+}: NotationContainerProps) => {
+  return (
+    <>
+      <div
+        ref={containerRef}
+        onClick={onClick}
+        style={{
+          overflow: 'visible',
+          width,
+          height,
+        }}
+      />
+      <SnackbarToast open={open} setOpen={setOpen} message={message} />
+      {children}
+    </>
+  );
+};
+
+export default NotationContainer;

--- a/app/lib/handleKeySigInteraction.ts
+++ b/app/lib/handleKeySigInteraction.ts
@@ -21,6 +21,9 @@ export const handleKeySigInteraction = (
   setKeySigState: (newState: React.SetStateAction<string[]>) => void,
   keySig: string[]
 ) => {
+  // Create a copy of the current glyphState that we'll modify and return
+  let updatedGlyphs = [...glyphState];
+
   if (state.isSharpActive || state.isFlatActive) {
     notesAndCoordinates = updateNotesAndCoordsWithAccidental(
       state,
@@ -28,38 +31,51 @@ export const handleKeySigInteraction = (
       notesAndCoordinates
     );
 
-    const glyphAdded = addGlyphs(
-      xClick,
-      yClick,
-      state,
-      glyphState,
-      setGlyphState
-    );
-
-    // Only update the key signature array if a glyph was successfully added
-    if (glyphAdded) {
-      updateKeySigArrayForGrading(foundNoteData, state, setKeySigState);
-    } else {
-      console.log("Not updating key signature array since glyph was not added");
+    // Add the new glyph
+    if (state.isSharpActive) {
+      const newGlyph: GlyphProps = {
+        xPosition: xClick - 5,
+        yPosition: yClick,
+        glyph: "accidentalSharp",
+      };
+      updatedGlyphs.push(newGlyph);
+    } else if (state.isFlatActive) {
+      const newGlyph: GlyphProps = {
+        xPosition: xClick - 5,
+        yPosition: yClick,
+        glyph: "accidentalFlat",
+      };
+      updatedGlyphs.push(newGlyph);
     }
+
+    // Update the state with our new glyphs
+    setGlyphState(updatedGlyphs);
+
+    // Only update the key signature array if we added a glyph
+    updateKeySigArrayForGrading(foundNoteData, state, setKeySigState);
   } else if (state.isEraseAccidentalActive) {
-    const glyphWasDeleted = deleteGlyphFromStave(
-      setGlyphState,
-      glyphState,
-      xClick,
-      yClick
-    );
-
-    if (glyphWasDeleted) {
-      deleteAccidentalFromKeySigArray(foundNoteData, keySig, setKeySigState);
-      notesAndCoordinates = removeAccidentalFromNotesAndCoords(
-        notesAndCoordinates,
-        foundNoteData
+    // Remove the glyph at the click position
+    updatedGlyphs = updatedGlyphs.filter((glyph) => {
+      const distance = Math.sqrt(
+        Math.pow(glyph.xPosition - xClick, 2) +
+          Math.pow(glyph.yPosition - yClick, 2)
       );
-    }
+      return distance > 20; // Filter out glyphs within 20px radius of click
+    });
+
+    // Update the state
+    setGlyphState(updatedGlyphs);
+
+    // Update other state values
+    deleteAccidentalFromKeySigArray(foundNoteData, keySig, setKeySigState);
+    notesAndCoordinates = removeAccidentalFromNotesAndCoords(
+      notesAndCoordinates,
+      foundNoteData
+    );
   }
 
   return {
     notesAndCoordinates,
+    updatedGlyphs, // Return the updated glyphs for immediate rendering
   };
 };

--- a/app/lib/handleScaleInteraction.ts
+++ b/app/lib/handleScaleInteraction.ts
@@ -183,7 +183,7 @@ export const HandleScaleInteraction = (
           userClickY: userY,
         };
 
-        // CRITICAL FIX: Add the updated note to our array at the SAME index
+        // Add the updated note to our array at the SAME index
         // This preserves the positioning and prevents duplicates
         freshBarData[targetNoteIndex] = updatedNote;
 
@@ -205,7 +205,7 @@ export const HandleScaleInteraction = (
           .sort((a, b) => a[0] - b[0]) // Sort by x position
           .map((entry) => entry[1]); // Extract just the note data
 
-        // CRITICAL FIX: We must update the ENTIRE matrix, not just one bar
+        // We must update the ENTIRE matrix, not just one bar
         // This ensures we don't lose state between operations
         matrixCopy[barIndex] = uniqueNotes;
 

--- a/app/lib/handleScaleInteraction.ts
+++ b/app/lib/handleScaleInteraction.ts
@@ -1,16 +1,13 @@
 import VexFlow from "vexflow";
-
 import {
   removeAccidentalFromNotesAndCoords,
   updateNotesAndCoordsWithAccidental,
 } from "./modifyNotesAndCoordinates";
 import {
-  addAccidentalToStaveNoteAndKeys,
   removeAccidentalFromStaveNote,
   removeNoteFromScale,
 } from "./modifyScales";
 import {
-  StateInteraction,
   NotesAndCoordinatesData,
   ScaleData,
   StaveNoteType,
@@ -21,41 +18,6 @@ import {
 type StaveType = ScaleData;
 
 const { StaveNote } = VexFlow.Flow;
-
-// Helper function to create a stave note with an accidental
-const createStaveNoteWithAccidental = (
-  originalNote: ScaleData,
-  originalKey: string,
-  newKey: string,
-  accidental: string,
-  chosenClef: string
-): ScaleData => {
-  // Create a new StaveNote with the updated key
-  const newNote = new StaveNote({
-    clef: chosenClef,
-    keys: [newKey],
-    duration: originalNote.duration || '4'
-  });
-  
-  // Add the accidental modifier if needed
-  if (accidental && (accidental === '#' || accidental === 'b')) {
-    console.log(`Adding ${accidental} accidental to note`);
-    // Create the accidental modifier and add it with the CORRECT parameter order
-    // VexFlow docs show: addModifier(modifier, index)
-    const accidentalModifier = new VexFlow.Flow.Accidental(accidental);
-    newNote.addModifier(accidentalModifier, 0); // First param is the modifier object, second is the index
-  }
-  
-  // Create proper ScaleData object to match the expected type
-  const resultNote: ScaleData = {
-    ...originalNote,
-    keys: [newKey],
-    staveNote: newNote,
-    exactX: originalNote.exactX // Preserve the X position
-  };
-  
-  return resultNote;
-};
 
 export const HandleScaleInteraction = (
   foundNoteData: NotesAndCoordinatesData,
@@ -77,113 +39,57 @@ export const HandleScaleInteraction = (
   setOpen: (newState: React.SetStateAction<boolean>) => void,
   errorMessages: errorMessages
 ) => {
-  // CRITICAL FIX: Double-check button states at point of interaction
-  // Log the actual button states we're receiving to help with debugging
-  console.log('🕵️‍♂️ HandleScaleInteraction received button states:', {
-    isSharpActive: buttonStates.isSharpActive,
-    isFlatActive: buttonStates.isFlatActive,
-    isEnterNoteActive: buttonStates.isEnterNoteActive,
-    isEraseNoteActive: buttonStates.isEraseNoteActive
-  });
-  
   // Create defensive copies to avoid any state mutation issues
   const stateCopy = { ...buttonStates };
 
-  console.log('HandleScaleInteraction called with:', {
-    buttonStates,
-    userClickX,
-    userClickY,
-    scaleLength: barOfScaleData.length,
-    noteKeys: barOfScaleData.map(note => note.keys?.[0])
-  });
-  
-  // Enhanced approach for finding existing notes
   const findExistingNoteIndex = () => {
     if (!barOfScaleData || barOfScaleData.length === 0) {
-      console.log('\n\n⚠️ No scale data available for note detection');
       return -1;
     }
-    
-    console.log('\n\n🔍 SEARCHING FOR EXISTING NOTES');
-    console.log(`Click position x=${userClickX}`);
-    console.log(`Total notes in this bar: ${barOfScaleData.length}`);
-    
-    // Find the note closest to the click position
+
     let closestIndex = -1;
     let closestDistance = Number.MAX_VALUE;
 
     // Loop through notes to find the closest one
     barOfScaleData.forEach((note, index) => {
-      // Only process notes that have a position
       if (note.exactX !== undefined) {
         const distance = Math.abs(note.exactX - userClickX);
-        const noteKey = note.keys && note.keys[0] ? note.keys[0] : 'unknown';
-        
-        console.log(`Note ${index}: key=${noteKey}, x=${note.exactX}, distance=${distance}px`);
-        
-        // CRITICAL FIX: Use a much larger threshold of 150px
-        // This ensures we detect notes even with less precise clicks
+        const noteKey = note.keys && note.keys[0] ? note.keys[0] : "unknown";
+
         if (distance < closestDistance && distance < 150) {
-          console.log(`🎯 FOUND NOTE: ${noteKey} at index ${index} with distance ${distance}px`);
           closestDistance = distance;
           closestIndex = index;
         }
-      } else {
-        console.log(`Note ${index} has no exactX coordinate - skipping`);
       }
     });
-    
-    // Report the results of our search
-    if (closestIndex !== -1) {
-      const matchedNote = barOfScaleData[closestIndex];
-      console.log(`✅ Found existing note at index ${closestIndex}:`);
-      console.log(`  - Key: ${matchedNote.keys?.[0]}`);
-      console.log(`  - Position: ${matchedNote.exactX}px`);
-      console.log(`  - Distance from click: ${Math.abs(matchedNote.exactX - userClickX)}px`);
-    } else {
-      console.log('❌ No existing note found near click position');
-    }
-    
+
     return closestIndex;
   };
 
   const scaleLength = scaleDataMatrix[0].length;
   const existingNoteIndex = findExistingNoteIndex();
   const existingNoteFound = existingNoteIndex !== -1;
-  
-  console.log('Existing note found:', existingNoteFound, existingNoteIndex, existingNoteFound ? `key=${barOfScaleData[existingNoteIndex]?.keys?.[0] || 'unknown'}` : '')
-  
-  // Enable a debug mode for detailed logging
-  const DEBUG = true;
-  
-  // CRITICAL FIX: This branch handles all accidental operations
-  // This version fixes both duplicate notes and ensures sharps/flats persist for all notes
+
+  // This branch handles all accidental operations
   if (stateCopy.isSharpActive || stateCopy.isFlatActive) {
-    console.log('🚨 ACCIDENTAL MODE ACTIVE - Fixing both duplicate notes and persistence issues');
-    
-    // Check if we have ANY notes at all before proceeding
     if (barOfScaleData.length === 0) {
-      console.log('⛔ No notes exist in this bar - cannot add accidentals to nothing');
       return { scaleDataMatrix, notesAndCoordinates };
     }
-    
+
     // Progressive note detection strategy
     let targetNoteIndex = existingNoteIndex;
     let progressiveDetectionUsed = false;
-    
+
     // If standard detection failed, try with a much more aggressive approach
     if (targetNoteIndex === -1) {
-      console.log('🔍 Using aggressive detection to find any suitable note');
-      
       let closestDistance = Number.MAX_VALUE;
-      
+
       barOfScaleData.forEach((note, index) => {
         if (note.exactX !== undefined) {
           const distance = Math.abs(note.exactX - userClickX);
-          
+
           // Extreme threshold of 350px to catch notes anywhere on screen
           if (distance < closestDistance && distance < 350) {
-            console.log(`📡 Found note at index ${index} with distance ${distance}px`);
             closestDistance = distance;
             targetNoteIndex = index;
             progressiveDetectionUsed = true;
@@ -191,63 +97,49 @@ export const HandleScaleInteraction = (
         }
       });
     }
-    
+
     // Last resort: take the first note if we still couldn't find one
     if (targetNoteIndex === -1 && barOfScaleData.length > 0) {
-      console.log('🧩 Last resort - using first available note');
       targetNoteIndex = 0;
       progressiveDetectionUsed = true;
     }
-    
+
     // Now we should have a note to modify
     if (targetNoteIndex !== -1) {
-      console.log(`🎯 Modifying note at index ${targetNoteIndex}${progressiveDetectionUsed ? ' (using progressive detection)' : ''}`);
-      
       try {
         // IMPORTANT: Create a deep copy of the entire matrix to ensure we don't lose any state
         const matrixCopy = [...scaleDataMatrix];
-        
+
         // Get a fresh copy of the current bar with all existing accidentals preserved
         if (!matrixCopy[barIndex]) {
           matrixCopy[barIndex] = [];
         }
         const freshBarData = [...matrixCopy[barIndex]];
-        
-        // Get the note we want to modify
+
         const noteToModify = freshBarData[targetNoteIndex];
         if (!noteToModify || !noteToModify.keys || !noteToModify.keys[0]) {
-          console.error('❌ Invalid note to modify:', noteToModify);
           return { scaleDataMatrix, notesAndCoordinates };
         }
-        
-        // Get the original note information
+
         const key = noteToModify.keys[0];
-        console.log(`Working with note: ${key} at position ${noteToModify.exactX}px`);
-        
-        // Extract the note components
-        const keyParts = key.split('/');
+        const keyParts = key.split("/");
         let noteName = keyParts[0];
         const octave = keyParts[1];
-        
-        // Determine which accidental to apply and clean the note name
-        const newAccidental = stateCopy.isSharpActive ? '#' : 'b';
-        
-        // CRITICAL FIX: Special handling for B and B-flat to prevent the Bb issue
-        // The note B is a special case because 'b' is both the note name and the flat symbol
+
+        const newAccidental = stateCopy.isSharpActive ? "#" : "b";
+
         let newKey;
-        
-        if (noteName.startsWith('b')) {
-          // Handle special case for B notes
-          if (noteName === 'b') {
+
+        // Special handling for B and B-flat:
+        if (noteName.startsWith("b")) {
+          if (noteName === "b") {
             // This is a B natural, so just add the accidental
             if (stateCopy.isSharpActive) {
-              // B# is actually C, but we'll keep it as B# for musical theory consistency
               newKey = `b${newAccidental}/${octave}`;
             } else {
-              // If adding flat to B, we get Bb
               newKey = `bb/${octave}`;
             }
-          } else if (noteName === 'bb') {
+          } else if (noteName === "bb") {
             // This is already a B-flat, don't replace the first 'b'
             if (stateCopy.isSharpActive) {
               // If adding sharp to Bb, we get back to B natural
@@ -259,49 +151,46 @@ export const HandleScaleInteraction = (
           } else {
             // Some other note with 'b' in it (like 'ab')
             // Remove any existing accidentals and add the new one
-            const cleanNoteName = noteName.replace(/[#b]/g, '');
+            const cleanNoteName = noteName.replace(/[#b]/g, "");
             newKey = `${cleanNoteName}${newAccidental}/${octave}`;
           }
         } else {
           // For all other notes, remove any existing accidentals and add the new one
-          const cleanNoteName = noteName.replace(/[#b]/g, '');
+          const cleanNoteName = noteName.replace(/[#b]/g, "");
           newKey = `${cleanNoteName}${newAccidental}/${octave}`;
         }
-        
-        console.log(`Transforming note from ${key} to ${newKey}`);
-        
+
         // Create a completely new StaveNote with the accidental
         const newStaveNote = new VexFlow.Flow.StaveNote({
           keys: [newKey],
-          duration: noteToModify.duration || 'q',
-          clef: chosenClef
+          duration: noteToModify.duration || "q",
+          clef: chosenClef,
         });
-        
-        // Add the accidental modifier with the correct parameter ordering
+
         const accidentalModifier = new VexFlow.Flow.Accidental(newAccidental);
-        newStaveNote.addModifier(accidentalModifier, 0); // First arg is modifier, second is index
-        
+        newStaveNote.addModifier(accidentalModifier, 0);
+
         // Save original position information
         const exactXPosition = noteToModify.exactX;
         const userY = noteToModify.userClickY;
-        
+
         // Create a complete replacement object
         const updatedNote = {
           keys: [newKey],
-          duration: noteToModify.duration || 'q',
+          duration: noteToModify.duration || "q",
           staveNote: newStaveNote,
           exactX: exactXPosition,
-          userClickY: userY
+          userClickY: userY,
         };
-        
+
         // CRITICAL FIX: Add the updated note to our array at the SAME index
         // This preserves the positioning and prevents duplicates
         freshBarData[targetNoteIndex] = updatedNote;
-        
+
         // Deduplicate notes based on exact positions to remove any overlaps
         // Build a map of positions to notes, keeping only unique positions
         const positionMap = new Map<number, ScaleData>();
-        
+
         for (let i = 0; i < freshBarData.length; i++) {
           const note = freshBarData[i];
           if (note && note.exactX !== undefined) {
@@ -310,47 +199,34 @@ export const HandleScaleInteraction = (
             positionMap.set(note.exactX, note);
           }
         }
-        
+
         // Convert the map back to an array sorted by x position
         const uniqueNotes: StaveType[] = Array.from(positionMap.entries())
           .sort((a, b) => a[0] - b[0]) // Sort by x position
-          .map(entry => entry[1]);  // Extract just the note data
-        
-        console.log(`Bar originally had ${freshBarData.length} notes, now has ${uniqueNotes.length} after deduplication`);
-        
-        // When updating a note with an accidental, ensure we're keeping track of ALL notes properly
-        // CRITICAL FIX: We need to debug what's happening with the state matrix between clicks
-        console.log('STATE DEBUG: Complete scale data matrix BEFORE update:', JSON.stringify(
-          scaleDataMatrix.map(bar => bar.map(note => note.keys?.[0] || 'unknown')), null, 2)
-        );
-        
+          .map((entry) => entry[1]); // Extract just the note data
+
         // CRITICAL FIX: We must update the ENTIRE matrix, not just one bar
         // This ensures we don't lose state between operations
         matrixCopy[barIndex] = uniqueNotes;
-        
-        // Log the complete state AFTER modification to track changes
-        console.log('STATE DEBUG: Complete scale data matrix AFTER update:', JSON.stringify(
-          matrixCopy.map(bar => bar.map(note => note.keys?.[0] || 'unknown')), null, 2)
-        );
-        
+
         // Update coordinates for display
         const updatedCoords = updateNotesAndCoordsWithAccidental(
           buttonStates,
           foundNoteData,
           notesAndCoordinates
         );
-        
+
         // Return the complete updated state
-        return { 
-          scaleDataMatrix: matrixCopy, 
-          notesAndCoordinates: updatedCoords 
+        return {
+          scaleDataMatrix: matrixCopy,
+          notesAndCoordinates: updatedCoords,
         };
       } catch (error) {
-        console.error('❌ Error applying accidental:', error);
+        console.error("Error applying accidental:", error);
         return { scaleDataMatrix, notesAndCoordinates };
       }
     } else {
-      console.log('❌ Failed to find any note to modify');
+      console.log("Failed to find any note to modify");
       return { scaleDataMatrix, notesAndCoordinates };
     }
   }
@@ -360,14 +236,14 @@ export const HandleScaleInteraction = (
       notesAndCoordinates,
       foundNoteData
     );
-    
+
     // Use the exact position of the found note
     const { updatedNoteObject, noteIndex } = removeAccidentalFromStaveNote(
       barOfScaleData,
       barOfScaleData[existingNoteIndex].exactX as number,
       chosenClef
     );
-    
+
     barOfScaleData[noteIndex] = updatedNoteObject;
     scaleDataMatrix[barIndex] = barOfScaleData;
   }
@@ -377,23 +253,28 @@ export const HandleScaleInteraction = (
       notesAndCoordinates,
       foundNoteData
     );
-    
+
     // Use the exact position of the found note
-    removeNoteFromScale(barOfScaleData, barOfScaleData[existingNoteIndex].exactX as number);
+    removeNoteFromScale(
+      barOfScaleData,
+      barOfScaleData[existingNoteIndex].exactX as number
+    );
     scaleDataMatrix[barIndex] = barOfScaleData;
-  } 
+  }
   // Check if there are too many notes in the measure
   else if (scaleLength >= 7) {
     setOpen(true);
     setMessage(errorMessages.tooManyNotesInMeasure);
   }
   // Only add a new note if we're not in any modification mode (sharp, flat, erase, etc.)
-  else if (!buttonStates.isSharpActive && 
-           !buttonStates.isFlatActive && 
-           !buttonStates.isEraseAccidentalActive && 
-           !buttonStates.isEraseNoteActive) {
+  else if (
+    !buttonStates.isSharpActive &&
+    !buttonStates.isFlatActive &&
+    !buttonStates.isEraseAccidentalActive &&
+    !buttonStates.isEraseNoteActive
+  ) {
     // We're in enter note mode (default) or no mode selected
-    
+
     const newStaveNote: StaveNoteType = new StaveNote({
       keys: [foundNoteData.note],
       duration: "q",
@@ -413,7 +294,7 @@ export const HandleScaleInteraction = (
     ];
 
     scaleDataMatrix[barIndex] = newNoteObject;
-  } 
+  }
   // If we got here, it means we're in a modification mode (sharp, flat, etc.) but didn't find a note to modify
   else {
     // Do nothing - we need a valid note to modify

--- a/app/lib/handleScaleInteraction.ts
+++ b/app/lib/handleScaleInteraction.ts
@@ -6,7 +6,6 @@ import {
 } from "./modifyNotesAndCoordinates";
 import {
   addAccidentalToStaveNoteAndKeys,
-  changeNotePosition,
   removeAccidentalFromStaveNote,
   removeNoteFromScale,
 } from "./modifyScales";
@@ -66,7 +65,6 @@ export const HandleScaleInteraction = (
   buttonStates: {
     isEnterNoteActive: boolean;
     isEraseNoteActive: boolean;
-    isChangeNoteActive: boolean;
     isSharpActive: boolean;
     isFlatActive: boolean;
     isEraseAccidentalActive: boolean;
@@ -349,33 +347,17 @@ export const HandleScaleInteraction = (
     // Use the exact position of the found note
     removeNoteFromScale(barOfScaleData, barOfScaleData[existingNoteIndex].exactX as number);
     scaleDataMatrix[barIndex] = barOfScaleData;
-  }
-  // Changing note position
-  else if (buttonStates.isChangeNoteActive && existingNoteFound) {
-    notesAndCoordinates = removeAccidentalFromNotesAndCoords(
-      notesAndCoordinates,
-      foundNoteData
-    );
-    
-    changeNotePosition(
-      barOfScaleData,
-      barOfScaleData[existingNoteIndex].exactX as number,
-      foundNoteData,
-      userClickY,
-      chosenClef
-    );
-    
-    scaleDataMatrix[barIndex] = barOfScaleData;
-  } else if (scaleLength >= 7) {
+  } 
+  // Check if there are too many notes in the measure
+  else if (scaleLength >= 7) {
     setOpen(true);
     setMessage(errorMessages.tooManyNotesInMeasure);
-  } 
+  }
   // Only add a new note if we're not in any modification mode (sharp, flat, erase, etc.)
   else if (!buttonStates.isSharpActive && 
            !buttonStates.isFlatActive && 
            !buttonStates.isEraseAccidentalActive && 
-           !buttonStates.isEraseNoteActive && 
-           !buttonStates.isChangeNoteActive) {
+           !buttonStates.isEraseNoteActive) {
     // We're in enter note mode (default) or no mode selected
     
     const newStaveNote: StaveNoteType = new StaveNote({

--- a/app/lib/handleScaleInteraction.ts
+++ b/app/lib/handleScaleInteraction.ts
@@ -40,57 +40,197 @@ export const HandleScaleInteraction = (
   setOpen: (newState: React.SetStateAction<boolean>) => void,
   errorMessages: errorMessages
 ) => {
+  console.log('HandleScaleInteraction called with:', {
+    buttonStates,
+    userClickX,
+    userClickY,
+    scaleLength: barOfScaleData.length,
+    noteKeys: barOfScaleData.map(note => note.keys?.[0])
+  });
+  
+  // Enhanced approach for finding existing notes
+  const findExistingNoteIndex = () => {
+    if (!barOfScaleData || barOfScaleData.length === 0) {
+      console.log('No scale data available for note detection');
+      return -1;
+    }
+    
+    // Find the note closest to the click position
+    let closestIndex = -1;
+    let closestDistance = Number.MAX_VALUE;
+    
+    // Safely log notes information
+    console.log('Existing notes:', barOfScaleData.map(note => ({
+      exactX: note.exactX,
+      keys: note.keys ? [...note.keys] : [] // Create a new array to avoid circular refs
+    })));
+    
+    barOfScaleData.forEach((note, index) => {
+      if (note.exactX !== undefined) { // Make sure exactX exists
+        const distance = Math.abs(note.exactX - userClickX);
+        
+        // Safely log note information without circular refs
+        const noteKey = note.keys && note.keys[0] ? note.keys[0] : 'unknown';
+        console.log(`Note ${index}, key=${noteKey}, exactX=${note.exactX}, distance=${distance}`);
+        
+        // Use a more generous threshold of 50px
+        if (distance < closestDistance && distance < 50) {
+          closestDistance = distance;
+          closestIndex = index;
+        }
+      } else {
+        console.log(`Note ${index} has no exactX coordinate`);
+      }
+    });
+    
+    console.log(`Closest note index: ${closestIndex}, distance: ${closestIndex !== -1 && barOfScaleData[closestIndex] && barOfScaleData[closestIndex].exactX !== undefined ? Math.abs(barOfScaleData[closestIndex].exactX - userClickX) : 'N/A'}`);
+    return closestIndex;
+  };
+
   const scaleLength = scaleDataMatrix[0].length;
-  if (buttonStates.isSharpActive || buttonStates.isFlatActive) {
+  const existingNoteIndex = findExistingNoteIndex();
+  const existingNoteFound = existingNoteIndex !== -1;
+  
+  console.log('Existing note found:', existingNoteFound, existingNoteIndex, existingNoteFound ? `key=${barOfScaleData[existingNoteIndex]?.keys?.[0] || 'unknown'}` : '')
+  
+  // If we have sharp or flat active and we found an existing note nearby
+  if ((buttonStates.isSharpActive || buttonStates.isFlatActive) && existingNoteFound) {
+    // First update the note coordinates for display
     notesAndCoordinates = updateNotesAndCoordsWithAccidental(
       buttonStates,
       foundNoteData,
       notesAndCoordinates
     );
-    const { updatedNoteObject, noteIndex } = addAccidentalToStaveNoteAndKeys(
-      buttonStates,
-      barOfScaleData,
-      userClickX,
-      chosenClef
-    );
-    barOfScaleData[noteIndex] = updatedNoteObject;
-    scaleDataMatrix[barIndex] = barOfScaleData;
-  } else if (buttonStates.isEraseAccidentalActive) {
+    
+    console.log('ACCIDENTAL MODE: Applying accidental to note at index', existingNoteIndex);
+    
+    try {
+      // Get the note we want to modify
+      const noteToModify = barOfScaleData[existingNoteIndex];
+      
+      if (!noteToModify || !noteToModify.keys || !noteToModify.keys[0]) {
+        console.error('Invalid note object:', noteToModify);
+        return { scaleDataMatrix, notesAndCoordinates };
+      }
+      
+      // Safely log without circular references
+      console.log('Note before modification:', {
+        keys: noteToModify.keys ? [...noteToModify.keys] : [],
+        exactX: noteToModify.exactX
+      });
+      
+      // Save the exact position so it doesn't move
+      const exactXPosition = noteToModify.exactX;
+      
+      // Determine which accidental to add
+      const accidental = buttonStates.isSharpActive ? "#" : "b";
+      
+      // Remove any existing accidentals first, then add the new one
+      const baseNote = noteToModify.keys[0].replace(/[#b]/g, '');
+      const updatedKey = baseNote + accidental;
+      
+      console.log(`Modifying note from ${noteToModify.keys[0]} to ${updatedKey}`);
+      
+      // Create a new stave note with the updated key
+      const newStaveNote = new VexFlow.Flow.StaveNote({
+        keys: [updatedKey],
+        duration: "q",
+        clef: chosenClef
+      });
+      
+      // Add the accidental modifier to make it visible
+      const mod = new VexFlow.Flow.Accidental(accidental);
+      newStaveNote.addModifier(mod);
+      
+      // Create a completely fresh object to avoid any state issues
+      const updatedNoteObject = {
+        keys: [updatedKey],
+        duration: "q",
+        staveNote: newStaveNote,
+        exactX: exactXPosition,  // Crucial: maintain the exact position
+        userClickY: noteToModify.userClickY // Maintain Y position if present
+      };
+      
+      console.log('New note object created:', {
+        keys: updatedNoteObject.keys ? [...updatedNoteObject.keys] : [],
+        exactX: updatedNoteObject.exactX
+      });
+      
+      // IMPORTANT: Make a completely fresh array to avoid React state issues
+      const freshBarData = [...barOfScaleData];
+      
+      // Replace the original note with our updated version
+      freshBarData[existingNoteIndex] = updatedNoteObject;
+      
+      // Update the data matrix with the fresh array at the right index
+      scaleDataMatrix[barIndex] = freshBarData;
+      
+      console.log('Updated scale data matrix with accidental');
+    } catch (error) {
+      console.error('Error adding accidental:', error);
+    }
+  } 
+  // If sharp/flat is active but no existing note, don't do anything (prevent adding new notes when accidental mode is on)
+  else if ((buttonStates.isSharpActive || buttonStates.isFlatActive) && !existingNoteFound) {
+    // Do nothing - we want to prevent adding new notes when in sharp/flat mode
+    // This prevents the bug where clicking with sharp active tries to add a new note
+  }
+  // Erasing accidentals from existing notes
+  else if (buttonStates.isEraseAccidentalActive && existingNoteFound) {
     notesAndCoordinates = removeAccidentalFromNotesAndCoords(
       notesAndCoordinates,
       foundNoteData
     );
+    
+    // Use the exact position of the found note
     const { updatedNoteObject, noteIndex } = removeAccidentalFromStaveNote(
       barOfScaleData,
-      userClickX,
+      barOfScaleData[existingNoteIndex].exactX as number,
       chosenClef
     );
+    
     barOfScaleData[noteIndex] = updatedNoteObject;
     scaleDataMatrix[barIndex] = barOfScaleData;
-  } else if (buttonStates.isEraseNoteActive) {
+  }
+  // Erasing notes
+  else if (buttonStates.isEraseNoteActive && existingNoteFound) {
     notesAndCoordinates = removeAccidentalFromNotesAndCoords(
       notesAndCoordinates,
       foundNoteData
     );
-    removeNoteFromScale(barOfScaleData, userClickX);
+    
+    // Use the exact position of the found note
+    removeNoteFromScale(barOfScaleData, barOfScaleData[existingNoteIndex].exactX as number);
     scaleDataMatrix[barIndex] = barOfScaleData;
-  } else if (buttonStates.isChangeNoteActive) {
+  }
+  // Changing note position
+  else if (buttonStates.isChangeNoteActive && existingNoteFound) {
     notesAndCoordinates = removeAccidentalFromNotesAndCoords(
       notesAndCoordinates,
       foundNoteData
     );
+    
     changeNotePosition(
       barOfScaleData,
-      userClickX,
+      barOfScaleData[existingNoteIndex].exactX as number,
       foundNoteData,
       userClickY,
       chosenClef
     );
+    
     scaleDataMatrix[barIndex] = barOfScaleData;
   } else if (scaleLength >= 7) {
     setOpen(true);
     setMessage(errorMessages.tooManyNotesInMeasure);
-  } else {
+  } 
+  // Only add a new note if we're not in any modification mode (sharp, flat, erase, etc.)
+  else if (!buttonStates.isSharpActive && 
+           !buttonStates.isFlatActive && 
+           !buttonStates.isEraseAccidentalActive && 
+           !buttonStates.isEraseNoteActive && 
+           !buttonStates.isChangeNoteActive) {
+    // We're in enter note mode (default) or no mode selected
+    
     const newStaveNote: StaveNoteType = new StaveNote({
       keys: [foundNoteData.note],
       duration: "q",
@@ -110,6 +250,11 @@ export const HandleScaleInteraction = (
     ];
 
     scaleDataMatrix[barIndex] = newNoteObject;
+  } 
+  // If we got here, it means we're in a modification mode (sharp, flat, etc.) but didn't find a note to modify
+  else {
+    // Do nothing - we need a valid note to modify
+    // This prevents adding notes when in modification mode
   }
   return {
     scaleDataMatrix,

--- a/app/lib/handleScaleInteraction.ts
+++ b/app/lib/handleScaleInteraction.ts
@@ -17,7 +17,46 @@ import {
   StaveNoteType,
   errorMessages,
 } from "./types";
+
+// Define alias for cleaner code
+type StaveType = ScaleData;
+
 const { StaveNote } = VexFlow.Flow;
+
+// Helper function to create a stave note with an accidental
+const createStaveNoteWithAccidental = (
+  originalNote: ScaleData,
+  originalKey: string,
+  newKey: string,
+  accidental: string,
+  chosenClef: string
+): ScaleData => {
+  // Create a new StaveNote with the updated key
+  const newNote = new StaveNote({
+    clef: chosenClef,
+    keys: [newKey],
+    duration: originalNote.duration || '4'
+  });
+  
+  // Add the accidental modifier if needed
+  if (accidental && (accidental === '#' || accidental === 'b')) {
+    console.log(`Adding ${accidental} accidental to note`);
+    // Create the accidental modifier and add it with the CORRECT parameter order
+    // VexFlow docs show: addModifier(modifier, index)
+    const accidentalModifier = new VexFlow.Flow.Accidental(accidental);
+    newNote.addModifier(accidentalModifier, 0); // First param is the modifier object, second is the index
+  }
+  
+  // Create proper ScaleData object to match the expected type
+  const resultNote: ScaleData = {
+    ...originalNote,
+    keys: [newKey],
+    staveNote: newNote,
+    exactX: originalNote.exactX // Preserve the X position
+  };
+  
+  return resultNote;
+};
 
 export const HandleScaleInteraction = (
   foundNoteData: NotesAndCoordinatesData,
@@ -40,6 +79,18 @@ export const HandleScaleInteraction = (
   setOpen: (newState: React.SetStateAction<boolean>) => void,
   errorMessages: errorMessages
 ) => {
+  // CRITICAL FIX: Double-check button states at point of interaction
+  // Log the actual button states we're receiving to help with debugging
+  console.log('🕵️‍♂️ HandleScaleInteraction received button states:', {
+    isSharpActive: buttonStates.isSharpActive,
+    isFlatActive: buttonStates.isFlatActive,
+    isEnterNoteActive: buttonStates.isEnterNoteActive,
+    isEraseNoteActive: buttonStates.isEraseNoteActive
+  });
+  
+  // Create defensive copies to avoid any state mutation issues
+  const stateCopy = { ...buttonStates };
+
   console.log('HandleScaleInteraction called with:', {
     buttonStates,
     userClickX,
@@ -51,39 +102,50 @@ export const HandleScaleInteraction = (
   // Enhanced approach for finding existing notes
   const findExistingNoteIndex = () => {
     if (!barOfScaleData || barOfScaleData.length === 0) {
-      console.log('No scale data available for note detection');
+      console.log('\n\n⚠️ No scale data available for note detection');
       return -1;
     }
+    
+    console.log('\n\n🔍 SEARCHING FOR EXISTING NOTES');
+    console.log(`Click position x=${userClickX}`);
+    console.log(`Total notes in this bar: ${barOfScaleData.length}`);
     
     // Find the note closest to the click position
     let closestIndex = -1;
     let closestDistance = Number.MAX_VALUE;
-    
-    // Safely log notes information
-    console.log('Existing notes:', barOfScaleData.map(note => ({
-      exactX: note.exactX,
-      keys: note.keys ? [...note.keys] : [] // Create a new array to avoid circular refs
-    })));
-    
+
+    // Loop through notes to find the closest one
     barOfScaleData.forEach((note, index) => {
-      if (note.exactX !== undefined) { // Make sure exactX exists
+      // Only process notes that have a position
+      if (note.exactX !== undefined) {
         const distance = Math.abs(note.exactX - userClickX);
-        
-        // Safely log note information without circular refs
         const noteKey = note.keys && note.keys[0] ? note.keys[0] : 'unknown';
-        console.log(`Note ${index}, key=${noteKey}, exactX=${note.exactX}, distance=${distance}`);
         
-        // Use a more generous threshold of 50px
-        if (distance < closestDistance && distance < 50) {
+        console.log(`Note ${index}: key=${noteKey}, x=${note.exactX}, distance=${distance}px`);
+        
+        // CRITICAL FIX: Use a much larger threshold of 150px
+        // This ensures we detect notes even with less precise clicks
+        if (distance < closestDistance && distance < 150) {
+          console.log(`🎯 FOUND NOTE: ${noteKey} at index ${index} with distance ${distance}px`);
           closestDistance = distance;
           closestIndex = index;
         }
       } else {
-        console.log(`Note ${index} has no exactX coordinate`);
+        console.log(`Note ${index} has no exactX coordinate - skipping`);
       }
     });
     
-    console.log(`Closest note index: ${closestIndex}, distance: ${closestIndex !== -1 && barOfScaleData[closestIndex] && barOfScaleData[closestIndex].exactX !== undefined ? Math.abs(barOfScaleData[closestIndex].exactX - userClickX) : 'N/A'}`);
+    // Report the results of our search
+    if (closestIndex !== -1) {
+      const matchedNote = barOfScaleData[closestIndex];
+      console.log(`✅ Found existing note at index ${closestIndex}:`);
+      console.log(`  - Key: ${matchedNote.keys?.[0]}`);
+      console.log(`  - Position: ${matchedNote.exactX}px`);
+      console.log(`  - Distance from click: ${Math.abs(matchedNote.exactX - userClickX)}px`);
+    } else {
+      console.log('❌ No existing note found near click position');
+    }
+    
     return closestIndex;
   };
 
@@ -93,87 +155,172 @@ export const HandleScaleInteraction = (
   
   console.log('Existing note found:', existingNoteFound, existingNoteIndex, existingNoteFound ? `key=${barOfScaleData[existingNoteIndex]?.keys?.[0] || 'unknown'}` : '')
   
-  // If we have sharp or flat active and we found an existing note nearby
-  if ((buttonStates.isSharpActive || buttonStates.isFlatActive) && existingNoteFound) {
-    // First update the note coordinates for display
-    notesAndCoordinates = updateNotesAndCoordsWithAccidental(
-      buttonStates,
-      foundNoteData,
-      notesAndCoordinates
-    );
+  // Enable a debug mode for detailed logging
+  const DEBUG = true;
+  
+  // CRITICAL FIX: This branch handles all accidental operations
+  // This version fixes both duplicate notes and ensures sharps/flats persist for all notes
+  if (stateCopy.isSharpActive || stateCopy.isFlatActive) {
+    console.log('🚨 ACCIDENTAL MODE ACTIVE - Fixing both duplicate notes and persistence issues');
     
-    console.log('ACCIDENTAL MODE: Applying accidental to note at index', existingNoteIndex);
+    // Check if we have ANY notes at all before proceeding
+    if (barOfScaleData.length === 0) {
+      console.log('⛔ No notes exist in this bar - cannot add accidentals to nothing');
+      return { scaleDataMatrix, notesAndCoordinates };
+    }
     
-    try {
-      // Get the note we want to modify
-      const noteToModify = barOfScaleData[existingNoteIndex];
+    // Progressive note detection strategy
+    let targetNoteIndex = existingNoteIndex;
+    let progressiveDetectionUsed = false;
+    
+    // If standard detection failed, try with a much more aggressive approach
+    if (targetNoteIndex === -1) {
+      console.log('🔍 Using aggressive detection to find any suitable note');
       
-      if (!noteToModify || !noteToModify.keys || !noteToModify.keys[0]) {
-        console.error('Invalid note object:', noteToModify);
+      let closestDistance = Number.MAX_VALUE;
+      
+      barOfScaleData.forEach((note, index) => {
+        if (note.exactX !== undefined) {
+          const distance = Math.abs(note.exactX - userClickX);
+          
+          // Extreme threshold of 350px to catch notes anywhere on screen
+          if (distance < closestDistance && distance < 350) {
+            console.log(`📡 Found note at index ${index} with distance ${distance}px`);
+            closestDistance = distance;
+            targetNoteIndex = index;
+            progressiveDetectionUsed = true;
+          }
+        }
+      });
+    }
+    
+    // Last resort: take the first note if we still couldn't find one
+    if (targetNoteIndex === -1 && barOfScaleData.length > 0) {
+      console.log('🧩 Last resort - using first available note');
+      targetNoteIndex = 0;
+      progressiveDetectionUsed = true;
+    }
+    
+    // Now we should have a note to modify
+    if (targetNoteIndex !== -1) {
+      console.log(`🎯 Modifying note at index ${targetNoteIndex}${progressiveDetectionUsed ? ' (using progressive detection)' : ''}`);
+      
+      try {
+        // IMPORTANT: Create a deep copy of the entire matrix to ensure we don't lose any state
+        const matrixCopy = [...scaleDataMatrix];
+        
+        // Get a fresh copy of the current bar with all existing accidentals preserved
+        if (!matrixCopy[barIndex]) {
+          matrixCopy[barIndex] = [];
+        }
+        const freshBarData = [...matrixCopy[barIndex]];
+        
+        // Get the note we want to modify
+        const noteToModify = freshBarData[targetNoteIndex];
+        if (!noteToModify || !noteToModify.keys || !noteToModify.keys[0]) {
+          console.error('❌ Invalid note to modify:', noteToModify);
+          return { scaleDataMatrix, notesAndCoordinates };
+        }
+        
+        // Get the original note information
+        const key = noteToModify.keys[0];
+        console.log(`Working with note: ${key} at position ${noteToModify.exactX}px`);
+        
+        // Extract the note components
+        const keyParts = key.split('/');
+        let noteName = keyParts[0];
+        const octave = keyParts[1];
+        
+        // Determine which accidental to apply and clean the note name
+        const newAccidental = stateCopy.isSharpActive ? '#' : 'b';
+        noteName = noteName.replace(/[#b]/g, ''); // Remove any existing accidentals
+        const newKey = `${noteName}${newAccidental}/${octave}`;
+        
+        console.log(`Transforming note from ${key} to ${newKey}`);
+        
+        // Create a completely new StaveNote with the accidental
+        const newStaveNote = new VexFlow.Flow.StaveNote({
+          keys: [newKey],
+          duration: noteToModify.duration || 'q',
+          clef: chosenClef
+        });
+        
+        // Add the accidental modifier with the correct parameter ordering
+        const accidentalModifier = new VexFlow.Flow.Accidental(newAccidental);
+        newStaveNote.addModifier(accidentalModifier, 0); // First arg is modifier, second is index
+        
+        // Save original position information
+        const exactXPosition = noteToModify.exactX;
+        const userY = noteToModify.userClickY;
+        
+        // Create a complete replacement object
+        const updatedNote = {
+          keys: [newKey],
+          duration: noteToModify.duration || 'q',
+          staveNote: newStaveNote,
+          exactX: exactXPosition,
+          userClickY: userY
+        };
+        
+        // CRITICAL FIX: Add the updated note to our array at the SAME index
+        // This preserves the positioning and prevents duplicates
+        freshBarData[targetNoteIndex] = updatedNote;
+        
+        // Deduplicate notes based on exact positions to remove any overlaps
+        // Build a map of positions to notes, keeping only unique positions
+        const positionMap = new Map<number, ScaleData>();
+        
+        for (let i = 0; i < freshBarData.length; i++) {
+          const note = freshBarData[i];
+          if (note && note.exactX !== undefined) {
+            // When two notes have the same position, the later one wins
+            // This ensures our modified note takes precedence if there's a conflict
+            positionMap.set(note.exactX, note);
+          }
+        }
+        
+        // Convert the map back to an array sorted by x position
+        const uniqueNotes: StaveType[] = Array.from(positionMap.entries())
+          .sort((a, b) => a[0] - b[0]) // Sort by x position
+          .map(entry => entry[1]);  // Extract just the note data
+        
+        console.log(`Bar originally had ${freshBarData.length} notes, now has ${uniqueNotes.length} after deduplication`);
+        
+        // When updating a note with an accidental, ensure we're keeping track of ALL notes properly
+        // CRITICAL FIX: We need to debug what's happening with the state matrix between clicks
+        console.log('STATE DEBUG: Complete scale data matrix BEFORE update:', JSON.stringify(
+          scaleDataMatrix.map(bar => bar.map(note => note.keys?.[0] || 'unknown')), null, 2)
+        );
+        
+        // CRITICAL FIX: We must update the ENTIRE matrix, not just one bar
+        // This ensures we don't lose state between operations
+        matrixCopy[barIndex] = uniqueNotes;
+        
+        // Log the complete state AFTER modification to track changes
+        console.log('STATE DEBUG: Complete scale data matrix AFTER update:', JSON.stringify(
+          matrixCopy.map(bar => bar.map(note => note.keys?.[0] || 'unknown')), null, 2)
+        );
+        
+        // Update coordinates for display
+        const updatedCoords = updateNotesAndCoordsWithAccidental(
+          buttonStates,
+          foundNoteData,
+          notesAndCoordinates
+        );
+        
+        // Return the complete updated state
+        return { 
+          scaleDataMatrix: matrixCopy, 
+          notesAndCoordinates: updatedCoords 
+        };
+      } catch (error) {
+        console.error('❌ Error applying accidental:', error);
         return { scaleDataMatrix, notesAndCoordinates };
       }
-      
-      // Safely log without circular references
-      console.log('Note before modification:', {
-        keys: noteToModify.keys ? [...noteToModify.keys] : [],
-        exactX: noteToModify.exactX
-      });
-      
-      // Save the exact position so it doesn't move
-      const exactXPosition = noteToModify.exactX;
-      
-      // Determine which accidental to add
-      const accidental = buttonStates.isSharpActive ? "#" : "b";
-      
-      // Remove any existing accidentals first, then add the new one
-      const baseNote = noteToModify.keys[0].replace(/[#b]/g, '');
-      const updatedKey = baseNote + accidental;
-      
-      console.log(`Modifying note from ${noteToModify.keys[0]} to ${updatedKey}`);
-      
-      // Create a new stave note with the updated key
-      const newStaveNote = new VexFlow.Flow.StaveNote({
-        keys: [updatedKey],
-        duration: "q",
-        clef: chosenClef
-      });
-      
-      // Add the accidental modifier to make it visible
-      const mod = new VexFlow.Flow.Accidental(accidental);
-      newStaveNote.addModifier(mod);
-      
-      // Create a completely fresh object to avoid any state issues
-      const updatedNoteObject = {
-        keys: [updatedKey],
-        duration: "q",
-        staveNote: newStaveNote,
-        exactX: exactXPosition,  // Crucial: maintain the exact position
-        userClickY: noteToModify.userClickY // Maintain Y position if present
-      };
-      
-      console.log('New note object created:', {
-        keys: updatedNoteObject.keys ? [...updatedNoteObject.keys] : [],
-        exactX: updatedNoteObject.exactX
-      });
-      
-      // IMPORTANT: Make a completely fresh array to avoid React state issues
-      const freshBarData = [...barOfScaleData];
-      
-      // Replace the original note with our updated version
-      freshBarData[existingNoteIndex] = updatedNoteObject;
-      
-      // Update the data matrix with the fresh array at the right index
-      scaleDataMatrix[barIndex] = freshBarData;
-      
-      console.log('Updated scale data matrix with accidental');
-    } catch (error) {
-      console.error('Error adding accidental:', error);
+    } else {
+      console.log('❌ Failed to find any note to modify');
+      return { scaleDataMatrix, notesAndCoordinates };
     }
-  } 
-  // If sharp/flat is active but no existing note, don't do anything (prevent adding new notes when accidental mode is on)
-  else if ((buttonStates.isSharpActive || buttonStates.isFlatActive) && !existingNoteFound) {
-    // Do nothing - we want to prevent adding new notes when in sharp/flat mode
-    // This prevents the bug where clicking with sharp active tries to add a new note
   }
   // Erasing accidentals from existing notes
   else if (buttonStates.isEraseAccidentalActive && existingNoteFound) {

--- a/app/lib/hooks/useNotationClickHandler.tsx
+++ b/app/lib/hooks/useNotationClickHandler.tsx
@@ -1,0 +1,58 @@
+import { RefObject, useCallback } from 'react';
+import { NotesAndCoordinatesData, StaveType } from '../types';
+import getUserClickInfo from '../getUserClickInfo';
+import { errorMessages } from '../data/errorMessages';
+
+type UseNotationClickHandlerProps = {
+  containerRef: RefObject<HTMLDivElement>;
+  staves: StaveType[];
+  notesAndCoordinates: NotesAndCoordinatesData[];
+  setOpen: (open: boolean) => void;
+  setMessage: (message: string) => void;
+};
+
+/**
+ * A custom hook for handling clicks on notation components
+ */
+export const useNotationClickHandler = ({
+  containerRef,
+  staves,
+  notesAndCoordinates,
+  setOpen,
+  setMessage,
+}: UseNotationClickHandlerProps) => {
+  
+  const getClickInfo = useCallback((e: React.MouseEvent) => {
+    if (!staves.length || !containerRef.current) {
+      return null;
+    }
+
+    const { userClickY, userClickX, topStaveYCoord, bottomStaveYCoord } = 
+      getUserClickInfo(e, containerRef, staves[0]);
+
+    let foundNoteData = notesAndCoordinates.find(
+      ({ yCoordinateMin, yCoordinateMax }) =>
+        userClickY >= yCoordinateMin && userClickY <= yCoordinateMax
+    );
+
+    if (!foundNoteData) {
+      setOpen(true);
+      setMessage(errorMessages.noNoteFound || "No note found at click position");
+      return null;
+    }
+
+    return {
+      userClickX,
+      userClickY,
+      topStaveYCoord,
+      bottomStaveYCoord,
+      foundNoteData: {
+        ...foundNoteData,
+        userClickX,
+        userClickY,
+      },
+    };
+  }, [staves, notesAndCoordinates, containerRef, setOpen, setMessage]);
+
+  return { getClickInfo };
+};

--- a/app/lib/hooks/useNotationRenderer.tsx
+++ b/app/lib/hooks/useNotationRenderer.tsx
@@ -1,0 +1,78 @@
+import { RefObject, useCallback, useEffect, useRef } from 'react';
+import VexFlow from 'vexflow';
+import { initializeRenderer } from '../initializeRenderer';
+import { StaveType } from '../types';
+
+type UseNotationRendererProps = {
+  containerRef: RefObject<HTMLDivElement>;
+  renderFunction: () => StaveType[] | undefined;
+  scaleFactor?: number;
+  width?: number;
+  height?: number;
+};
+
+/**
+ * A custom hook for handling VexFlow notation rendering
+ * 
+ * This hook follows the pattern described in our circular dependency solution
+ * where the render function is stored in a ref and not a direct dependency.
+ */
+export const useNotationRenderer = ({
+  containerRef,
+  renderFunction,
+  scaleFactor = 1.5,
+  width = 470,
+  height = 200,
+}: UseNotationRendererProps) => {
+  const rendererRef = useRef<InstanceType<typeof VexFlow.Flow.Renderer> | null>(null);
+  const hasScaled = useRef<boolean>(false);
+  const renderFunctionRef = useRef(renderFunction);
+  
+  // Update the render function ref when it changes
+  // This prevents the effect from re-running when the function changes
+  useEffect(() => {
+    renderFunctionRef.current = renderFunction;
+  }, [renderFunction]);
+  
+  // Initialize the renderer - only depends on containerRef, not the render function
+  useEffect(() => {
+    if (containerRef.current) {
+      initializeRenderer(rendererRef, containerRef);
+      // Only call render if we have a renderer
+      if (rendererRef.current) {
+        // Use the ref to the function, not the function itself
+        renderFunctionRef.current();
+      }
+    }
+  }, [containerRef]); // Remove renderFunction dependency
+
+  // Apply scaling to the SVG
+  useEffect(() => {
+    if (!hasScaled.current && containerRef.current) {
+      const svgElement = containerRef.current.querySelector("svg");
+      if (svgElement) {
+        svgElement.style.transform = `scale(${scaleFactor})`;
+        svgElement.style.transformOrigin = "0 0";
+        
+        // Adjust container size to accommodate scaled SVG
+        containerRef.current.style.height = `${height * scaleFactor}px`;
+        containerRef.current.style.width = `${width * scaleFactor}px`;
+        hasScaled.current = true;
+      }
+    }
+  }, [containerRef, scaleFactor, width, height]);
+
+  // Provide a stable function to re-render explicitly when needed
+  const render = useCallback(() => {
+    if (rendererRef.current && renderFunctionRef.current) {
+      return renderFunctionRef.current();
+    }
+    return undefined;
+  }, [rendererRef]); // Only depend on rendererRef, not renderFunctionRef which is stable
+
+  return {
+    rendererRef,
+    hasScaled,
+    render, // Expose render method for explicit calls after state changes
+  };
+};

--- a/app/lib/indexOfNoteToModify.ts
+++ b/app/lib/indexOfNoteToModify.ts
@@ -4,8 +4,9 @@ export const indexOfNoteToModify = (
   scaleData: ScaleData[] | StaveNoteData[],
   userClickX: number
 ): number => {
+  // Increased threshold to 30px for better note detection
   const index: number = scaleData?.findIndex(
-    (note) => Math.abs(note.exactX - userClickX) <= 10
+    (note) => Math.abs(note.exactX - userClickX) <= 30
   );
   return index;
 };

--- a/app/lib/initialStates.ts
+++ b/app/lib/initialStates.ts
@@ -1,5 +1,17 @@
-import { Chord, InputState, NotesAndCoordinatesData } from "./types";
+/**
+ * This file contains initial state definitions for various components in the application.
+ * Centralizing these states here makes them easier to maintain and reuse.
+ */
 
+import { Chord, InputState, NotesAndCoordinatesData, ProgressionState } from "./types";
+
+// -----------------------------------------------------------------------------
+// Notation Component Initial States
+// -----------------------------------------------------------------------------
+
+/**
+ * Initial state for chord data
+ */
 export const initialChordData: Chord = {
   keys: [],
   duration: "w",
@@ -7,6 +19,9 @@ export const initialChordData: Chord = {
   userClickY: 0,
 };
 
+/**
+ * Initial state for notes and coordinates data
+ */
 export const initialNotesAndCoordsState: NotesAndCoordinatesData = {
   note: "",
   originalNote: "",
@@ -14,41 +29,14 @@ export const initialNotesAndCoordsState: NotesAndCoordinatesData = {
   yCoordinateMax: 0,
 };
 
-export const initialFormInputState: InputState = {
-  userId: "",
-  user: null,
-  level: "select-here",
-  keySignatures: {},
-  keySignaturesNotation1: [],
-  keySignaturesNotation2: [],
-  keySignaturesNotation3: [],
-  keySignaturesNotation4: [],
-  scales1: [],
-  scales2: [],
-  scales3: [],
-  scales4: [],
-  scales5: [],
-  scales6: [],
-  triads1: [],
-  triads2: [],
-  triads3: [],
-  triads4: [],
-  triads5: [],
-  triads6: [],
-  seventhChords1: [],
-  seventhChords2: [],
-  seventhChords3: [],
-  seventhChords4: [],
-  seventhChords5: [],
-  seventhChords6: [],
-  seventhChords7: [],
-  chords: {},
-  progressions: {},
-  blues: {},
-  bluesUrl: "",
-};
+// -----------------------------------------------------------------------------
+// Form Input Initial States
+// -----------------------------------------------------------------------------
 
-export const initialProgressionInputState = {
+/**
+ * Initial state for progression inputs
+ */
+export const initialProgressionInputState: ProgressionState = {
   0: "Dm7",
   1: "G7",
   2: "Cmaj7",
@@ -67,4 +55,52 @@ export const initialProgressionInputState = {
   15: "",
   16: "",
   17: "",
+};
+
+/**
+ * Initial state for the main form inputs
+ */
+export const initialFormInputState: InputState = {
+  // User information
+  userId: "",
+  user: null,
+  level: "select-here",
+  
+  // Key signatures section
+  keySignatures: {},
+  keySignaturesNotation1: [],
+  keySignaturesNotation2: [],
+  keySignaturesNotation3: [],
+  keySignaturesNotation4: [],
+  
+  // Scales section
+  scales1: [],
+  scales2: [],
+  scales3: [],
+  scales4: [],
+  scales5: [],
+  scales6: [],
+  
+  // Triads section
+  triads1: [],
+  triads2: [],
+  triads3: [],
+  triads4: [],
+  triads5: [],
+  triads6: [],
+  
+  // Seventh chords section
+  seventhChords1: [],
+  seventhChords2: [],
+  seventhChords3: [],
+  seventhChords4: [],
+  seventhChords5: [],
+  seventhChords6: [],
+  seventhChords7: [],
+  
+  // Other sections
+  chords: {},
+  progressions: {},
+  blues: {},
+  bluesUrl: "",
 };

--- a/app/lib/modifyKeySignature.ts
+++ b/app/lib/modifyKeySignature.ts
@@ -45,16 +45,15 @@ export const addGlyphs = (
   );
 
   if (existingGlyphIndex !== -1) {
-    console.log("Glyph already exists at this position, not adding");
+    console.error("Glyph already exists at this position, not adding");
     return false;
   }
 
-  console.log("Adding new glyph:", newState);
   setGlyphState((prevState) => {
     // Double-check that the glyph doesn't already exist in the state
     // This handles race conditions where the state might have been updated but not yet reflected in glyphs
     if (prevState.some((glyph) => glyph.yPosition === newState.yPosition)) {
-      console.log("Glyph already exists in state, not adding");
+      console.error("Glyph already exists in state, not adding");
       return prevState;
     }
 
@@ -73,7 +72,6 @@ export const updateKeySigArrayForGrading = (
   const noteBase = parseNote(foundNoteData.note).noteBase;
 
   if (noteBase.length > 1) {
-    console.log("Note base length > 1, returning early:", noteBase);
     return;
   }
 
@@ -83,9 +81,7 @@ export const updateKeySigArrayForGrading = (
 
   // Use a callback function to ensure we're working with the latest state
   setKeySigState((prevState) => {
-    // Check if this note (with this accidental) is already in the key signature
     if (prevState.includes(noteWithAccidental)) {
-      console.log("Note already in key sig, not adding:", noteWithAccidental);
       return prevState;
     }
 

--- a/app/lib/modifyScales.ts
+++ b/app/lib/modifyScales.ts
@@ -34,43 +34,30 @@ export const getNoteData = (
   barOfScaleData: ScaleData[],
   userClickX: number
 ): ModifyScaleData => {
-  console.log('getNoteData called with:', {
-    userClickX,
-    barOfScaleData: barOfScaleData.map(note => ({
-      exactX: note.exactX,
-      keys: note.keys
-    }))
-  });
-  
   // First try to find the exact note using the regular index function
   let noteIndex = indexOfNote(barOfScaleData, userClickX);
-  
+
   // If that fails, use a more generous approach with a larger threshold
   if (noteIndex === -1 && barOfScaleData.length > 0) {
-    console.log('Note not found with standard indexOfNote, trying with larger threshold');
-    
     // Find the closest note within 50px
     let closestDistance = Number.MAX_VALUE;
     let closestIndex = -1;
-    
+
     barOfScaleData.forEach((note, index) => {
       if (note.exactX !== undefined) {
         const distance = Math.abs(note.exactX - userClickX);
-        console.log(`Note ${index} distance: ${distance}`);
         if (distance < closestDistance && distance < 50) {
           closestDistance = distance;
           closestIndex = index;
         }
       }
     });
-    
+
     if (closestIndex !== -1) {
-      console.log(`Found note with larger threshold at index ${closestIndex}`);
       noteIndex = closestIndex;
     }
   }
-  
-  console.log(`Final note index selected: ${noteIndex}`);
+
   return { noteDataObject: barOfScaleData[noteIndex], noteIndex };
 };
 
@@ -110,55 +97,40 @@ export const addAccidentalToStaveNoteAndKeys = (
 ) => {
   // Get the note to modify
   let { noteDataObject, noteIndex } = getNoteData(scaleData, userClickX);
-  
-  // Log which note we found
-  console.log('addAccidentalToStaveNoteAndKeys working with:', {
-    noteIndex,
-    noteData: noteDataObject ? {
-      keys: noteDataObject.keys,
-      exactX: noteDataObject.exactX
-    } : 'undefined'
-  });
-  
+
   // If no note was found or noteIndex is -1, we can't add an accidental
   if (noteIndex === -1 || !noteDataObject) {
-    console.error('No note found to add accidental to');
+    console.error("No note found to add accidental to");
     // Return a default object that won't modify anything
     return { updatedNoteObject: scaleData[0], noteIndex: 0 };
   }
-  
+
   // Determine the accidental based on which button is active
   const accidental = noteInteractionState.isSharpActive ? "#" : "b";
-  
+
   // Apply the accidental to the note
-  const updatedKey = appendAccidentalToNote(
-    accidental,
-    noteDataObject.keys[0]
-  );
-  
-  console.log(`Adding ${accidental} to ${noteDataObject.keys[0]} -> ${updatedKey}`);
-  
+  const updatedKey = appendAccidentalToNote(accidental, noteDataObject.keys[0]);
+
   // Create a new stave note with the updated key
   const newKeys = [updatedKey];
-  const newStaveNote = createStaveNoteFromScaleData(noteDataObject, chosenClef, newKeys);
-  
+  const newStaveNote = createStaveNoteFromScaleData(
+    noteDataObject,
+    chosenClef,
+    newKeys
+  );
+
   // Add the accidental visual to the stave note
   addAccidentalsToStaveNotes(newKeys, newStaveNote);
-  
+
   // Create the updated note object with the new keys and stave note
   const updatedNoteObject = {
     ...noteDataObject,
     staveNote: newStaveNote,
     keys: newKeys,
     // Make sure we preserve the exactX position
-    exactX: noteDataObject.exactX
+    exactX: noteDataObject.exactX,
   };
-  
-  console.log('Updated note object:', {
-    keys: updatedNoteObject.keys,
-    exactX: updatedNoteObject.exactX
-  });
-  
+
   return { updatedNoteObject, noteIndex };
 };
 

--- a/app/lib/modifyScales.ts
+++ b/app/lib/modifyScales.ts
@@ -209,15 +209,23 @@ export const changeNotePosition = (
   chosenClef: string
 ) => {
   const { noteDataObject, noteIndex } = getNoteData(scaleData, userClickX);
-  if (noteDataObject && noteDataObject.staveNote) {
-    const exactX = noteDataObject.staveNote.getAbsoluteX();
-
+  if (noteDataObject) {
+    // CRITICAL FIX: Don't use getAbsoluteX() which requires a TickContext
+    // Instead, use the stored exactX property which always exists
+    const exactX = noteDataObject.exactX;
+    
+    console.log(`Changing note at position ${exactX}px from ${noteDataObject.keys?.[0]} to ${foundNoteData.note}`);
+    
+    // Create a new StaveNote with the updated properties
+    const newStaveNote = new StaveNote({
+      keys: [foundNoteData.note],
+      duration: "q",
+      clef: chosenClef,
+    });
+    
+    // Replace the old note with the new one, preserving the exactX position
     scaleData.splice(noteIndex, 1, {
-      staveNote: new StaveNote({
-        keys: [foundNoteData.note],
-        duration: "q",
-        clef: chosenClef,
-      }),
+      staveNote: newStaveNote,
       keys: [foundNoteData.note],
       duration: "q",
       exactX,

--- a/app/lib/modifyScales.ts
+++ b/app/lib/modifyScales.ts
@@ -201,39 +201,6 @@ export const addNewNoteToScale = (
   return newNoteObject;
 };
 
-export const changeNotePosition = (
-  scaleData: ScaleData[],
-  userClickX: number,
-  foundNoteData: NotesAndCoordinatesData,
-  userClickY: number,
-  chosenClef: string
-) => {
-  const { noteDataObject, noteIndex } = getNoteData(scaleData, userClickX);
-  if (noteDataObject) {
-    // CRITICAL FIX: Don't use getAbsoluteX() which requires a TickContext
-    // Instead, use the stored exactX property which always exists
-    const exactX = noteDataObject.exactX;
-    
-    console.log(`Changing note at position ${exactX}px from ${noteDataObject.keys?.[0]} to ${foundNoteData.note}`);
-    
-    // Create a new StaveNote with the updated properties
-    const newStaveNote = new StaveNote({
-      keys: [foundNoteData.note],
-      duration: "q",
-      clef: chosenClef,
-    });
-    
-    // Replace the old note with the new one, preserving the exactX position
-    scaleData.splice(noteIndex, 1, {
-      staveNote: newStaveNote,
-      keys: [foundNoteData.note],
-      duration: "q",
-      exactX,
-      userClickY,
-    });
-  }
-};
-
 export const removeNoteFromScale = (
   scaleData: ScaleData[],
   userClickX: number

--- a/app/lib/setupRendererAndDrawNotes.ts
+++ b/app/lib/setupRendererAndDrawNotes.ts
@@ -60,10 +60,43 @@ export const setupRendererAndDrawNotes = (
 
       barOfNoteObjects.forEach((noteObj) => {
         console.log("noteObj from forEach:", noteObj);
+        
+        // CRITICAL FIX: Enhance accidental detection and rendering
+        // Check if the note has an accidental in its key name
+        const hasAccidental = noteObj.keys && noteObj.keys[0]?.includes('#') || noteObj.keys?.[0]?.includes('b');
+        console.log(`Note ${noteObj.keys?.[0]} has accidental: ${hasAccidental}`);
+        
         if (noteObj.staveNote) {
           noteObj.staveNote.setStave(currentStave);
           noteObj.staveNote.setContext(context);
-
+          
+          // CRITICAL FIX: Ensure accidentals are properly added to the staveNote
+          // We need to re-add accidentals manually if they exist in the key name
+          if (hasAccidental) {
+            const keyInfo = noteObj.keys?.[0];
+            if (keyInfo) {
+              // Extract the accidental symbol
+              const accidentalSymbol = keyInfo.includes('#') ? '#' : 'b';
+              
+              console.log(`Ensuring accidental ${accidentalSymbol} is visible on note ${keyInfo}`);
+              
+              // Create a new accidental modifier and add it to the staveNote
+              // This ensures the accidental will be visible when the note is drawn
+              const accidentalModifier = new VexFlow.Flow.Accidental(accidentalSymbol);
+              
+              // Check if this note already has an accidental (avoid duplicates)
+              const existingAccidentals = noteObj.staveNote.getModifiers();
+              const hasExistingAccidental = existingAccidentals.some(
+                mod => mod.getCategory() === 'accidentals'
+              );
+              
+              if (!hasExistingAccidental) {
+                console.log(`Adding accidental ${accidentalSymbol} to note ${keyInfo}`);
+                noteObj.staveNote.addModifier(accidentalModifier, 0);
+              }
+            }
+          }
+          
           // Position and draw the note at the exact click position
           if (noteObj.exactX) {
             // Create a separate tick context for each note to prevent them from affecting each other

--- a/app/lib/setupRendererAndDrawNotes.ts
+++ b/app/lib/setupRendererAndDrawNotes.ts
@@ -59,70 +59,59 @@ export const setupRendererAndDrawNotes = (
       const currentStave = staves[index] || newStaves[index];
 
       barOfNoteObjects.forEach((noteObj) => {
-        console.log("noteObj from forEach:", noteObj);
-        
         // CRITICAL FIX: Enhance accidental detection and rendering
         // Check if the note has an accidental in its key name - use a more precise pattern
+        const keyName = noteObj.keys?.[0] || "";
+
         // Fix the special case of 'b/4' (B natural) vs 'bb/4' (B flat)
-        const keyName = noteObj.keys?.[0] || '';
-        
         // Special handling for B-flat to prevent it from turning back into B natural
-        // This is critical as 'b' is both the note B and the flat accidental symbol
-        const isBFlat = keyName.length >= 2 && keyName.startsWith('bb');
-        
+        const isBFlat = keyName.length >= 2 && keyName.startsWith("bb");
+
         // Only consider it a sharp if it's actually a sharp
-        const hasSharp = keyName.includes('#');
-        
-        // For flats, we need more careful detection now:
-        // 1. 'b/4' is B natural, not a flat
-        // 2. 'bb/4' is specifically B-flat
-        // 3. 'ab/4', 'cb/4', etc. are normal flats for other notes
-        const keyPart = keyName.split('/')[0]; // Get just the note name without octave
-        
+        const hasSharp = keyName.includes("#");
+
+        const keyPart = keyName.split("/")[0]; // Get just the note name without octave
+
+        // For flats, we need more careful detection:
         // A note has a flat if:
         // - It specifically is B-flat ('bb/4') OR
         // - It contains 'b' but is not just the note B ('b/4')
-        const hasFlat = isBFlat || (keyPart.includes('b') && (keyPart !== 'b'));
-        
+        const hasFlat = isBFlat || (keyPart.includes("b") && keyPart !== "b");
+
         const hasAccidental = hasSharp || hasFlat;
-        
-        // Debug log to track how we're detecting accidentals
-        console.log(`Note ${keyName} - isBFlat: ${isBFlat}, hasSharp: ${hasSharp}, hasFlat: ${hasFlat}, hasAccidental: ${hasAccidental}`);
-        
+
         if (noteObj.staveNote) {
           noteObj.staveNote.setStave(currentStave);
           noteObj.staveNote.setContext(context);
-          
-          // CRITICAL FIX: Ensure accidentals are properly added to the staveNote
+
+          // Ensure accidentals are properly added to the staveNote:
           // We need to re-add accidentals manually if they exist in the key name
           if (hasAccidental) {
-            // Extract the accidental symbol from the key name
-            let accidentalSymbol = '';
+            let accidentalSymbol = "";
             if (hasSharp) {
-              accidentalSymbol = '#';
+              accidentalSymbol = "#";
             } else if (hasFlat) {
-              accidentalSymbol = 'b';
+              accidentalSymbol = "b";
             }
-            
+
             if (accidentalSymbol) {
-              console.log(`Ensuring accidental ${accidentalSymbol} is visible on note ${keyName}`);
-              
               // Create a new accidental modifier and add it to the staveNote
-              const accidentalModifier = new VexFlow.Flow.Accidental(accidentalSymbol);
-              
+              const accidentalModifier = new VexFlow.Flow.Accidental(
+                accidentalSymbol
+              );
+
               // Check if this note already has an accidental (avoid duplicates)
               const existingAccidentals = noteObj.staveNote.getModifiers();
               const hasExistingAccidental = existingAccidentals.some(
-                mod => mod.getCategory() === 'accidentals'
+                (mod) => mod.getCategory() === "accidentals"
               );
-              
+
               if (!hasExistingAccidental) {
-                console.log(`Adding accidental ${accidentalSymbol} to note ${keyName}`);
                 noteObj.staveNote.addModifier(accidentalModifier, 0);
               }
             }
           }
-          
+
           // Position and draw the note at the exact click position
           if (noteObj.exactX) {
             // Create a separate tick context for each note to prevent them from affecting each other

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -270,3 +270,11 @@ export interface EmailData {
   subject?: string;
   text?: string;
 }
+
+/**
+ * Represents the state of chord progressions
+ * Maps position indices to chord symbols
+ */
+export interface ProgressionState {
+  [key: string]: string;
+}

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -16,7 +16,6 @@ export type InputData = {
 export type ButtonStates = {
   isEnterNoteActive: boolean;
   isEraseNoteActive: boolean;
-  isChangeNoteActive: boolean;
   isSharpActive: boolean;
   isFlatActive: boolean;
   isEraseAccidentalActive: boolean;

--- a/app/lib/useButtonStates.ts
+++ b/app/lib/useButtonStates.ts
@@ -4,7 +4,6 @@ import { Dispatch, SetStateAction, useCallback, useState } from 'react';
 export interface ButtonStates {
   isEnterNoteActive: boolean;
   isEraseNoteActive: boolean;
-  isChangeNoteActive: boolean;
   isSharpActive: boolean;
   isFlatActive: boolean;
   isEraseAccidentalActive: boolean;
@@ -15,7 +14,6 @@ export interface ButtonStates {
 export interface ButtonSetters {
   setIsEnterNoteActive: Dispatch<SetStateAction<boolean>>;
   setIsEraseNoteActive: Dispatch<SetStateAction<boolean>>;
-  setIsChangeNoteActive: Dispatch<SetStateAction<boolean>>;
   setIsSharpActive: Dispatch<SetStateAction<boolean>>;
   setIsFlatActive: Dispatch<SetStateAction<boolean>>;
   setIsEraseAccidentalActive: Dispatch<SetStateAction<boolean>>;
@@ -41,7 +39,6 @@ type ButtonStateConfig = string[];
 export const useButtonStates = (buttonIds: ButtonStateConfig = [
   'enterNote',
   'eraseNote',
-  'changeNote',
   'sharp',
   'flat',
   'eraseAccidental'
@@ -56,7 +53,6 @@ export const useButtonStates = (buttonIds: ButtonStateConfig = [
   const defaultStates: ButtonStates = {
     isEnterNoteActive: false,
     isEraseNoteActive: false,
-    isChangeNoteActive: false,
     isSharpActive: false,
     isFlatActive: false,
     isEraseAccidentalActive: false,
@@ -67,7 +63,6 @@ export const useButtonStates = (buttonIds: ButtonStateConfig = [
   const settersMap: ButtonSetters = {
     setIsEnterNoteActive: () => {}, // Will be overridden if present in buttonStates
     setIsEraseNoteActive: () => {},
-    setIsChangeNoteActive: () => {},
     setIsSharpActive: () => {},
     setIsFlatActive: () => {},
     setIsEraseAccidentalActive: () => {},

--- a/app/lib/useButtonStates.ts
+++ b/app/lib/useButtonStates.ts
@@ -1,39 +1,110 @@
-import { useState } from 'react';
+import { Dispatch, SetStateAction, useCallback, useState } from 'react';
 
-export const useButtonStates = () => {
-  const [isEnterNoteActive, setIsEnterNoteActive] = useState(false);
-  const [isEraseNoteActive, setIsEraseNoteActive] = useState(false);
-  const [isChangeNoteActive, setIsChangeNoteActive] = useState(false);
-  const [isSharpActive, setIsSharpActive] = useState(false);
-  const [isFlatActive, setIsFlatActive] = useState(false);
-  const [isEraseAccidentalActive, setIsEraseAccidentalActive] = useState(false);
+// Define the legacy button states interface that's expected by existing components
+export interface ButtonStates {
+  isEnterNoteActive: boolean;
+  isEraseNoteActive: boolean;
+  isChangeNoteActive: boolean;
+  isSharpActive: boolean;
+  isFlatActive: boolean;
+  isEraseAccidentalActive: boolean;
+  [key: string]: boolean; // Allow additional properties for extensibility
+}
 
-  const clearAllStates = () => {
-    setIsEnterNoteActive(false);
-    setIsEraseNoteActive(false);
-    setIsChangeNoteActive(false);
-    setIsSharpActive(false);
-    setIsFlatActive(false);
-    setIsEraseAccidentalActive(false);
+// Define the legacy setters interface
+export interface ButtonSetters {
+  setIsEnterNoteActive: Dispatch<SetStateAction<boolean>>;
+  setIsEraseNoteActive: Dispatch<SetStateAction<boolean>>;
+  setIsChangeNoteActive: Dispatch<SetStateAction<boolean>>;
+  setIsSharpActive: Dispatch<SetStateAction<boolean>>;
+  setIsFlatActive: Dispatch<SetStateAction<boolean>>;
+  setIsEraseAccidentalActive: Dispatch<SetStateAction<boolean>>;
+  [key: string]: Dispatch<SetStateAction<boolean>>; // Allow additional properties for extensibility
+}
+
+// New expanded button state type
+export type ButtonState = {
+  id: string;
+  isActive: boolean;
+  setter: Dispatch<SetStateAction<boolean>>;
+};
+
+type ButtonStateConfig = string[];
+
+/**
+ * A more flexible hook for managing button states in notation components
+ * 
+ * @param buttonIds - Array of button state IDs to initialize
+ * @param initialActiveId - Optional ID of the initially active button
+ * @returns Button states, setActive utility function, and clearAll utility function
+ */
+export const useButtonStates = (buttonIds: ButtonStateConfig = [
+  'enterNote',
+  'eraseNote',
+  'changeNote',
+  'sharp',
+  'flat',
+  'eraseAccidental'
+], initialActiveId?: string) => {
+  // Create state for each button
+  const buttonStates = buttonIds.map(id => {
+    const [isActive, setIsActive] = useState(id === initialActiveId);
+    return { id, isActive, setter: setIsActive };
+  });
+
+  // Default values for the legacy interface, ensuring type compatibility
+  const defaultStates: ButtonStates = {
+    isEnterNoteActive: false,
+    isEraseNoteActive: false,
+    isChangeNoteActive: false,
+    isSharpActive: false,
+    isFlatActive: false,
+    isEraseAccidentalActive: false,
   };
+  
+  // Initialize with default values first
+  const statesMap = { ...defaultStates };
+  const settersMap: ButtonSetters = {
+    setIsEnterNoteActive: () => {}, // Will be overridden if present in buttonStates
+    setIsEraseNoteActive: () => {},
+    setIsChangeNoteActive: () => {},
+    setIsSharpActive: () => {},
+    setIsFlatActive: () => {},
+    setIsEraseAccidentalActive: () => {},
+  };
+  
+  buttonStates.forEach(state => {
+    // Convert from camelCase ids to is{PascalCase}Active format for backwards compatibility
+    const pascalCaseId = state.id.charAt(0).toUpperCase() + state.id.slice(1);
+    const legacyStateKey = `is${pascalCaseId}Active`;
+    const legacySetterKey = `setIs${pascalCaseId}Active`;
+    
+    statesMap[legacyStateKey] = state.isActive;
+    // @ts-ignore - We know this setter exists at runtime
+    settersMap[legacySetterKey] = state.setter;
+  });
+
+  // Set a specific button as active and deactivate all others
+  const setActive = useCallback((buttonId: string) => {
+    buttonStates.forEach(state => {
+      state.setter(state.id === buttonId);
+    });
+  }, [buttonStates]);
+
+  // Clear all button states (set all to inactive)
+  const clearAllStates = useCallback(() => {
+    buttonStates.forEach(state => {
+      state.setter(false);
+    });
+  }, [buttonStates]);
 
   return {
-    states: {
-      isEnterNoteActive,
-      isEraseNoteActive,
-      isChangeNoteActive,
-      isSharpActive,
-      isFlatActive,
-      isEraseAccidentalActive,
-    },
-    setters: {
-      setIsEnterNoteActive,
-      setIsEraseNoteActive,
-      setIsChangeNoteActive,
-      setIsSharpActive,
-      setIsFlatActive,
-      setIsEraseAccidentalActive,
-    },
+    // New interface
+    buttonStates,
+    setActive,
     clearAllStates,
+    // Legacy interface for backward compatibility
+    states: statesMap,
+    setters: settersMap,
   };
 };


### PR DESCRIPTION
- Major refactor of the NotateChord, NotateKeysignature, and NotateScale files.
- Added hooks folder with new hooks usenotationClickHandler and useNotationRenderer.
- handleKeySigInteraction now to return updatedGlyphs state.
- handleScaleInteraction refactored.
- Added code to setupRendererAndDrawNotes file that detects when note has accidental ("G#/4") and checks if StaveNote oject already has an accidental modifier and if not, it adds it.
- In modifyScales, changed the getAbsoluteX logic to use exactX.
- In setupRendererAndDrawNotes, added more checks to determine if just a "b" or "bb".
- Removed the Change Note button entirely from the codebase as it is not needed - Removed from UI in NotateScale, from types in ButtonStates and mentions of isChangeNoteActive
- Added logic to setupRendererAndDrawNotes to determine and preserve Bb notes, as well as updating handleScaleInteraction starts with 'b' or 'bb'
- Cleaned out old unneeded console logs and comments, and other unneeded code