### PR TITLE
Misc tweaks

### DIFF
--- a/app/(routes)/exam/page.tsx
+++ b/app/(routes)/exam/page.tsx
@@ -24,7 +24,6 @@ import {
   correctKeySigAnswers,
   correctKeySigNotationAnswers,
   correctProgressionAnswers,
-  cMajorExampleAnswers,
   correctProgressionNonRegexAnswers,
   correctScalesAnswers,
   correctTriadNotes,
@@ -702,7 +701,7 @@ export default function ExamHomePage() {
             </Stack>
           </Box>
         )}
-        {viewState !== VIEW_STATES.SUBMIT_AND_EXIT &&
+        {/* {viewState !== VIEW_STATES.SUBMIT_AND_EXIT &&
           viewState !== VIEW_STATES.START_TEST && (
             <Stack spacing={4}>
               <Button onClick={incrementViewState}>
@@ -720,7 +719,7 @@ export default function ExamHomePage() {
                 <Typography>{"Print Data"}</Typography>
               </Button>
             </Stack>
-          )}
+          )} */}
       </Stack>
     </Box>
   );

--- a/app/(routes)/exam/page.tsx
+++ b/app/(routes)/exam/page.tsx
@@ -701,7 +701,7 @@ export default function ExamHomePage() {
             </Stack>
           </Box>
         )}
-        {/* {viewState !== VIEW_STATES.SUBMIT_AND_EXIT &&
+        {viewState !== VIEW_STATES.SUBMIT_AND_EXIT &&
           viewState !== VIEW_STATES.START_TEST && (
             <Stack spacing={4}>
               <Button onClick={incrementViewState}>
@@ -719,7 +719,7 @@ export default function ExamHomePage() {
                 <Typography>{"Print Data"}</Typography>
               </Button>
             </Stack>
-          )} */}
+          )}
       </Stack>
     </Box>
   );

--- a/app/(routes)/exam/page.tsx
+++ b/app/(routes)/exam/page.tsx
@@ -24,6 +24,7 @@ import {
   correctKeySigAnswers,
   correctKeySigNotationAnswers,
   correctProgressionAnswers,
+  cMajorExampleAnswers,
   correctProgressionNonRegexAnswers,
   correctScalesAnswers,
   correctTriadNotes,
@@ -701,7 +702,7 @@ export default function ExamHomePage() {
             </Stack>
           </Box>
         )}
-        {/* {viewState !== VIEW_STATES.SUBMIT_AND_EXIT &&
+        {viewState !== VIEW_STATES.SUBMIT_AND_EXIT &&
           viewState !== VIEW_STATES.START_TEST && (
             <Stack spacing={4}>
               <Button onClick={incrementViewState}>
@@ -719,7 +720,7 @@ export default function ExamHomePage() {
                 <Typography>{"Print Data"}</Typography>
               </Button>
             </Stack>
-          )} */}
+          )}
       </Stack>
     </Box>
   );

--- a/app/components/CardFooter.tsx
+++ b/app/components/CardFooter.tsx
@@ -7,7 +7,7 @@ export default function CardFooter({
   height = 100,
   pageNumber,
   buttonType = "submit",
-  buttonText = "Save and Continue >",
+  buttonText = "Continue >",
   handleSubmit,
   buttonForm,
 }: CardFooterProps) {

--- a/app/components/WriteProgression.tsx
+++ b/app/components/WriteProgression.tsx
@@ -8,7 +8,7 @@ import isCurrentDataFilled from "../lib/isCurrentDataFilled";
 import { ChangeEvent, FormEvent, WriteProps } from "../lib/types";
 import FormInput from "./FormInput";
 import Staff from "./Staff";
-import { Box, Typography } from "@mui/material";
+import { Typography } from "@mui/material";
 
 export default forwardRef(function WriteProgression(
   { width, handleInput, currentData }: WriteProps,

--- a/app/lib/__tests__/calculateAnswers.test.ts
+++ b/app/lib/__tests__/calculateAnswers.test.ts
@@ -7,10 +7,13 @@ import {
 } from "../calculateAnswers";
 
 describe("checkAndFormat251Answers", () => {
-  test("should correctly format student answers and calculate score", () => {
+  test("should correctly format student answers and calculate score with empty test answers", () => {
+    // Test case 1: With only C Major examples in student answers, but empty test answers
     const studentAnswers = ["Cmaj7", "D7", "G7"];
-    const regexCorrectAnswers = [/Cmaj7/, /D7/, /G7/];
-    const nonRegexCorrectAnswers = ["Cmaj7", "D7", "G7"];
+    // In the new structure, regexCorrectAnswers only contains the actual test questions (none in this case)
+    const regexCorrectAnswers: RegExp[] = [];
+    // nonRegexCorrectAnswers also only contains the actual test answers (none in this case)
+    const nonRegexCorrectAnswers: string[] = [];
     const questionType = "251 Chords";
 
     const result = checkAndFormat251Answers(
@@ -20,8 +23,39 @@ describe("checkAndFormat251Answers", () => {
       questionType
     );
 
+    // Should show score as 0/0 since there are no test questions
+    expect(result).toContain("<b>0/0</b>");
+    // Should not contain any answers in the formatted list since there are none
+    expect(result).not.toContain("<li>Cmaj7, D7, G7</li>");
+    expect(result).toContain("<ul>Actual student answers:");
+    // Correct answers should be empty since there are none
+    expect(result).toContain("<ul>Correct answers: </ul>");
+  });
+
+  test("should handle answers with both C Major examples and actual test answers", () => {
+    // Test case with C Major examples (first 3) and additional answers
+    const studentAnswers = ["Cmaj7", "D7", "G7", "Fmaj7", "Bb7", "Ebmaj7"];
+    // In the new structure, regexCorrectAnswers only contains the actual test questions
+    const regexCorrectAnswers = [/Fmaj7/, /Bb7/, /Ebmaj7/];
+    // nonRegexCorrectAnswers also only contains the actual test answers
+    const nonRegexCorrectAnswers = ["Fmaj7", "Bb7", "Ebmaj7"];
+    const questionType = "251 Chords";
+
+    const result = checkAndFormat251Answers(
+      studentAnswers,
+      regexCorrectAnswers,
+      nonRegexCorrectAnswers,
+      questionType
+    );
+
+    // Should show score as 3/3 (3 correct answers)
     expect(result).toContain("<b>3/3</b>");
-    expect(result).toContain("<li>Cmaj7, D7, G7</li>");
+    // Should not contain C Major examples
+    expect(result).not.toContain("<li>Cmaj7, D7, G7");
+    // Should contain the actual test answers
+    expect(result).toContain("<li>Fmaj7, Bb7, Ebmaj7</li>");
+    // Correct answers should only include the actual test answers
+    expect(result).toContain("<ul>Correct answers: Fmaj7, Bb7, Ebmaj7</ul>");
   });
 });
 
@@ -154,13 +188,11 @@ describe("checkAndFormatChordAnswers", () => {
       ["C", "E", "G"],
       ["D", "F", "A"],
     ];
-    const correctAnswers = [/CEG/, /DFA/];
     const correctAnswersText = ["C, E, G", "D, F, A"];
     const questionType = "Chord Answers";
 
     const result = checkAndFormatChordAnswers(
       userAnswers,
-      correctAnswers,
       correctAnswersText,
       questionType
     );
@@ -175,13 +207,11 @@ describe("checkAndFormatChordAnswers", () => {
       ["C", "E", "G"],
       ["D", "F#", "A"],
     ];
-    const correctAnswers = [/CEG/, /DFA/];
     const correctAnswersText = ["C, E, G", "D, F, A"];
     const questionType = "Chord Answers";
 
     const result = checkAndFormatChordAnswers(
       userAnswers,
-      correctAnswers,
       correctAnswersText,
       questionType
     );

--- a/app/lib/calculateAnswers.ts
+++ b/app/lib/calculateAnswers.ts
@@ -6,25 +6,44 @@ export const checkAndFormat251Answers = (
 ): string => {
   let score = 0;
   let formattedAnswers = "";
+  // The nonRegexCorrectAnswers now only contains the actual test answers (no C Major examples)
   let correctAnswers = nonRegexCorrectAnswers.join(", ");
 
+  // Calculate score for all answers in the regexCorrectAnswers array
+  // Note: regexCorrectAnswers should now only contain the actual test questions
   for (let i = 0; i < regexCorrectAnswers.length; i++) {
-    let chord = studentAnswers[i] || "";
+    // We need to offset the student answers by 3 to skip the C Major examples
+    // that the student still had to answer but aren't counted in the score
+    let chord = studentAnswers[i + 3] || "";
     let isCorrect = regexCorrectAnswers[i].test(chord);
     if (isCorrect) {
       score++;
     }
+  }
+
+  // Format answers (all answers are actual test answers now, no need to skip)
+  for (let i = 0; i < regexCorrectAnswers.length; i++) {
+    // We need to offset the student answers by 3 to skip the C Major examples
+    let chord = studentAnswers[i + 3] || "";
+    let isCorrect = regexCorrectAnswers[i].test(chord);
+
     if (i % 3 === 0) {
       if (i !== 0) formattedAnswers += "</li>";
       formattedAnswers += "<li>";
     }
     formattedAnswers += isCorrect ? chord : `<b>${chord || "(No answer)"}</b>`;
-    if (i % 3 !== 2) formattedAnswers += ", ";
+    if (i % 3 !== 2 && i < regexCorrectAnswers.length - 1)
+      formattedAnswers += ", ";
   }
 
-  formattedAnswers += "</li>";
+  if (formattedAnswers) {
+    formattedAnswers += "</li>";
+  }
 
-  const result = `<b>${score}/${regexCorrectAnswers.length}</b> on the ${questionType} section.
+  // Total questions is now just the length of the regexCorrectAnswers array
+  const totalQuestions = regexCorrectAnswers.length;
+  
+  const result = `<b>${score}/${totalQuestions}</b> on the ${questionType} section.
     <ul>Actual student answers:
       ${formattedAnswers}
     </ul>

--- a/app/lib/calculateAnswers.ts
+++ b/app/lib/calculateAnswers.ts
@@ -9,11 +9,7 @@ export const checkAndFormat251Answers = (
   // The nonRegexCorrectAnswers now only contains the actual test answers (no C Major examples)
   let correctAnswers = nonRegexCorrectAnswers.join(", ");
 
-  // Calculate score for all answers in the regexCorrectAnswers array
-  // Note: regexCorrectAnswers should now only contain the actual test questions
   for (let i = 0; i < regexCorrectAnswers.length; i++) {
-    // We need to offset the student answers by 3 to skip the C Major examples
-    // that the student still had to answer but aren't counted in the score
     let chord = studentAnswers[i + 3] || "";
     let isCorrect = regexCorrectAnswers[i].test(chord);
     if (isCorrect) {
@@ -40,9 +36,8 @@ export const checkAndFormat251Answers = (
     formattedAnswers += "</li>";
   }
 
-  // Total questions is now just the length of the regexCorrectAnswers array
   const totalQuestions = regexCorrectAnswers.length;
-  
+
   const result = `<b>${score}/${totalQuestions}</b> on the ${questionType} section.
     <ul>Actual student answers:
       ${formattedAnswers}

--- a/app/lib/data/answerKey.ts
+++ b/app/lib/data/answerKey.ts
@@ -67,12 +67,15 @@ export const correctSeventhChordNonRegexAnswers: string[] = [
   "D+7", // D augmented 7
 ];
 
-export const correctProgressionAnswers = [
-  //1
+// C Major example answers (not counted in student score)
+export const cMajorExampleAnswers = [
   /^(D)(?:-7|min7|mi7|m7)$/,
   /^(G7)$/,
   /^(C)(?:∆|∆7|[Mm]aj7|[Mm]a7)$/,
-  //2
+];
+
+export const correctProgressionAnswers = [
+  //2 - First actual test question
   /^(F#)(?:ø|ø7|-7b5|m7b5|min7b5|mi7b5)$/,
   /^(B7)(?:\(?b9\)?|\(?#9b9\)?|\(?b9#9\)?|\(?b13\)?|\(?alt\)?|\(?b13b9\)?|\(?b9b13\)?|\(?b13#9b9\)?||\(?b13b9#9\)?|\(?#9b9b13\)?|\(?b9#9b13\)?|\(?#9b13\)?)$/,
   /^(E)(?:-7|min7|mi7|m7|m6|mi6|min6|-6)$/,
@@ -94,8 +97,11 @@ export const correctProgressionAnswers = [
   /^(Gb)(?:-7|min7|mi7|m7|m6|mi6|min6|-6)$/,
 ];
 
+// C Major example answers text (not counted in student score)
+export const cMajorExampleAnswersText = ["D-7 G7 C∆"];
+
+// Actual test answers that are counted in student score
 export const correctProgressionNonRegexAnswers = [
-  "D-7 G7 C∆",
   "F#ø B7 E-7",
   "Eb-7 Ab7 Db∆",
   "D#ø G#7 C#-7",

--- a/app/lib/data/answerKey.ts
+++ b/app/lib/data/answerKey.ts
@@ -67,13 +67,6 @@ export const correctSeventhChordNonRegexAnswers: string[] = [
   "D+7", // D augmented 7
 ];
 
-// C Major example answers (not counted in student score)
-export const cMajorExampleAnswers = [
-  /^(D)(?:-7|min7|mi7|m7)$/,
-  /^(G7)$/,
-  /^(C)(?:∆|∆7|[Mm]aj7|[Mm]a7)$/,
-];
-
 export const correctProgressionAnswers = [
   //2 - First actual test question
   /^(F#)(?:ø|ø7|-7b5|m7b5|min7b5|mi7b5)$/,
@@ -97,10 +90,7 @@ export const correctProgressionAnswers = [
   /^(Gb)(?:-7|min7|mi7|m7|m6|mi6|min6|-6)$/,
 ];
 
-// C Major example answers text (not counted in student score)
-export const cMajorExampleAnswersText = ["D-7 G7 C∆"];
-
-// Actual test answers that are counted in student score
+// Actual test answers that are counted in student score (not including C Major examples)
 export const correctProgressionNonRegexAnswers = [
   "F#ø B7 E-7",
   "Eb-7 Ab7 Db∆",

--- a/app/lib/data/answerKey.ts
+++ b/app/lib/data/answerKey.ts
@@ -69,9 +69,9 @@ export const correctSeventhChordNonRegexAnswers: string[] = [
 
 export const correctProgressionAnswers = [
   //2 - First actual test question
-  /^(F#)(?:ø|ø7|-7b5|m7b5|min7b5|mi7b5)$/,
-  /^(B7)(?:\(?b9\)?|\(?#9b9\)?|\(?b9#9\)?|\(?b13\)?|\(?alt\)?|\(?b13b9\)?|\(?b9b13\)?|\(?b13#9b9\)?||\(?b13b9#9\)?|\(?#9b9b13\)?|\(?b9#9b13\)?|\(?#9b13\)?)$/,
-  /^(E)(?:-7|min7|mi7|m7|m6|mi6|min6|-6)$/,
+  /^(E#)(?:-7|min7|mi7|m7)$/,
+  /^(A#7)$/,
+  /^(D#)(?:∆|∆7|[Mm]aj7|[Mm]a7)$/,
   //3
   /^(Eb)(?:-7|min7|mi7|m7)$/,
   /^(Ab7)$/,
@@ -81,9 +81,9 @@ export const correctProgressionAnswers = [
   /^(G#7)(?:\(?b9\)?|\(?#9b9\)?|\(?b9#9\)?|\(?b13\)?|\(?alt\)?|\(?b13b9\)?|\(?b9b13\)?|\(?b13#9b9\)?||\(?b13b9#9\)?|\(?#9b9b13\)?|\(?b9#9b13\)?|\(?#9b13\)?)$/,
   /^(C#)(?:-7|min7|mi7|m7|m6|mi6|min6|-6)$/,
   //5
-  /^(E#)(?:-7|min7|mi7|m7)$/,
-  /^(A#7)$/,
-  /^(D#)(?:∆|∆7|[Mm]aj7|[Mm]a7)$/,
+  /^(F#)(?:ø|ø7|-7b5|m7b5|min7b5|mi7b5)$/,
+  /^(B7)(?:\(?b9\)?|\(?#9b9\)?|\(?b9#9\)?|\(?b13\)?|\(?alt\)?|\(?b13b9\)?|\(?b9b13\)?|\(?b13#9b9\)?||\(?b13b9#9\)?|\(?#9b9b13\)?|\(?b9#9b13\)?|\(?#9b13\)?)$/,
+  /^(E)(?:-7|min7|mi7|m7|m6|mi6|min6|-6)$/,
   //6
   /^(Ab)(?:ø|ø7|-7b5|m7b5|min7b5|mi7b5)$/,
   /^(Db7)(?:\(?b9\)?|\(?#9b9\)?|\(?b9#9\)?|\(?b13\)?|\(?alt\)?|\(?b13b9\)?|\(?b9b13\)?|\(?b13#9b9\)?||\(?b13b9#9\)?|\(?#9b9b13\)?|\(?b9#9b13\)?|\(?#9b13\)?)$/,
@@ -92,9 +92,9 @@ export const correctProgressionAnswers = [
 
 // Actual test answers that are counted in student score (not including C Major examples)
 export const correctProgressionNonRegexAnswers = [
-  "F#ø B7 E-7",
+  "E#-7 A#7 D#∆",
   "Eb-7 Ab7 Db∆",
   "D#ø G#7 C#-7",
-  "E#-7 A#7 D#∆",
+  "F#ø B7 E-7",
   "Abø Db7 Gb-7",
 ];

--- a/app/lib/data/instructions.js
+++ b/app/lib/data/instructions.js
@@ -13,7 +13,7 @@ export const keySigNotationInstructions = [
   },
   {
     instructionTitle: "Start over or continue:",
-    instructionText: `You can erase the measure and start over by selecting the “Clear Key” button. When finished, click "Save and Continue".`,
+    instructionText: `You can erase the measure and start over by selecting the “Clear Key” button. When finished, click "Continue".`,
   },
 ];
 
@@ -28,7 +28,7 @@ export const scalesNotationInstructions = [
   },
   {
     instructionTitle: "Start over or continue:",
-    instructionText: `You can erase the measure and start over by selecting the “Clear All” button. When finished, click "Save and Continue".`,
+    instructionText: `You can erase the measure and start over by selecting the “Clear All” button. When finished, click "Continue".`,
   },
 ];
 
@@ -43,7 +43,7 @@ export const chordsNotationInstructions = [
   },
   {
     instructionTitle: "Start over or continue:",
-    instructionText: `You can erase the measure and start over by selecting the “Clear All" button. When finished, click "Save and Continue".`,
+    instructionText: `You can erase the measure and start over by selecting the “Clear All" button. When finished, click "Continue".`,
   },
 ];
 
@@ -54,7 +54,7 @@ export const keySigInputInstructions = [
   },
   {
     instructionTitle: "Submit:",
-    instructionText: `When finished, click the "Save and Continue" button to move on to the next question.`,
+    instructionText: `When finished, click the "Continue" button to move on to the next question.`,
   },
   {
     instructionTitle: "Allowed to return to this page:",

--- a/app/lib/data/keyNamesText.js
+++ b/app/lib/data/keyNamesText.js
@@ -1,9 +1,9 @@
 const keyNames = [
   "C Major",
-  "E minor",
+  "D# Major",
   "Db Major",
   "C# minor",
-  "D# Major",
+  "E minor",
   "Gb minor",
 ];
 

--- a/cypress/e2e/lafsmwTests.cy.ts
+++ b/cypress/e2e/lafsmwTests.cy.ts
@@ -33,7 +33,7 @@ describe("Authenticated tests", () => {
     cy.get('[data-testid="card-footer"]')
       .should("exist")
       .within(() => {
-        cy.get("button").should("contain.text", "Save and Continue >");
+        cy.get("button").should("contain.text", "Continue >");
         cy.get("p").should("contain.text", "Page: 1/27");
       });
 
@@ -42,10 +42,10 @@ describe("Authenticated tests", () => {
       .and("have.attr", "aria-valuenow", "3");
 
     // Perform an action to update the progress bar:
-    // Click the "Save and Continue >" button to go to the next page
+    // Click the "Continue >" button to go to the next page
     cy.get('[data-testid="card-footer"]')
       .find("button")
-      .contains("Save and Continue >")
+      .contains("Continue >")
       .click();
 
     // Verify the progress bar has updated

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["es5", "dom"],
+    "types": ["cypress", "node"],
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "baseUrl": "../",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
- Changed "Save and Continue" to just "Continue"
- Added tsconfig to the Cypress testing directory to fix cy type
- Modified calculateAnswers 251 chord calculation to exclude the example answers and only 15/15 instead of 18
- Modified the calculateAnswers test accordingly
- Rearrangee the 251 chord progressions so the major keys are on top and the minor on the bottom - switch the D# Major and E minor