### PR TITLE
Refactor/org name

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,8 @@
 {
   "permissions": {
     "allow": [
-      "Bash(git log:*)"
+      "Bash(git log:*)",
+      "Bash(git show:*)"
     ],
     "deny": [],
     "ask": []

--- a/README.md
+++ b/README.md
@@ -21,16 +21,15 @@
 
 ## About
 
-This web application was contracted to Lydian Labs Technology by Lafayette Summer Jazz Workshop director Kyle Athayde. Its functional purpose is to replace their current music theory entrance exam.
+This web application was contracted to Lydian Lab Music by Lafayette Summer Jazz Workshop director Kyle Athayde. Its functional purpose is to replace their current music theory entrance exam.
 [Click here for more information about the camp](https://lafayettejazz.wpcomstaging.com/auditions/)
-  
+
 ### Features
 
 - Interactive notation: note input/erase and sharp and flat input via mouse click
 - Automated grading
 - Timed test: automatically goes to final submit button page after alotted time is up
 - Clear, minimalist design to allow for a comfortable, distraction-free user experience
-
 
 ### Developer Features
 
@@ -40,6 +39,7 @@ This web application was contracted to Lydian Labs Technology by Lafayette Summe
 - Error monitoring with Sentry
 
 ### Examples
+
 <img width="1705" alt="Screenshot 2024-06-26 at 5 20 08 PM" src="https://github.com/Lydian-Labs/lafsmw-theory-test/assets/76603041/7561b846-83dd-4730-ace6-96e80eaf20b8">
 <img width="1704" alt="Screenshot 2024-06-26 at 5 20 40 PM" src="https://github.com/Lydian-Labs/lafsmw-theory-test/assets/76603041/baf2a1fa-f554-450c-a2fc-b8de87b152fe">
 <img width="1703" alt="Screenshot 2024-06-26 at 5 22 22 PM" src="https://github.com/Lydian-Labs/lafsmw-theory-test/assets/76603041/81da7ffe-bb78-4fbc-bb56-8dacf6478aca">
@@ -51,4 +51,4 @@ This web application was contracted to Lydian Labs Technology by Lafayette Summe
 
 <br />
 
-Copyright© Lydian Labs Music Education Technology, 2024
+Copyright © Lydian Lab Music, 2026

--- a/app/(routes)/exam/page.tsx
+++ b/app/(routes)/exam/page.tsx
@@ -368,7 +368,7 @@ export default function ExamHomePage() {
             <li>Link to blues progression pdf: ${correctedAnswers[8]}</li>
           </ul>
 
-          <p>Thank you,<br>Team at Lydian Labs Technology.</p>`,
+          <p>Thank you,<br>Team at Lydian Lab Music.</p>`,
         }),
       });
       if (!response.ok) {

--- a/app/lib/__tests__/calculateAnswers.test.ts
+++ b/app/lib/__tests__/calculateAnswers.test.ts
@@ -27,9 +27,9 @@ describe("checkAndFormat251Answers", () => {
     expect(result).toContain("<b>0/0</b>");
     // Should not contain any answers in the formatted list since there are none
     expect(result).not.toContain("<li>Cmaj7, D7, G7</li>");
-    expect(result).toContain("<ul>Actual student answers:");
+    expect(result).toContain("<ol>Actual student answers:");
     // Correct answers should be empty since there are none
-    expect(result).toContain("<ul>Correct answers: </ul>");
+    expect(result).toContain("<ol>Correct answers:");
   });
 
   test("should handle answers with both C Major examples and actual test answers", () => {
@@ -55,7 +55,8 @@ describe("checkAndFormat251Answers", () => {
     // Should contain the actual test answers
     expect(result).toContain("<li>Fmaj7, Bb7, Ebmaj7</li>");
     // Correct answers should only include the actual test answers
-    expect(result).toContain("<ul>Correct answers: Fmaj7, Bb7, Ebmaj7</ul>");
+    expect(result).toContain("<ol>Correct answers:");
+    expect(result).toContain("<li>Fmaj7</li><li>Bb7</li><li>Ebmaj7</li>");
   });
 });
 
@@ -73,7 +74,7 @@ describe("checkAndFormatKeySigIdentifyAnswers", () => {
 
     expect(result).toContain("<b>3/3</b>");
     expect(result).toContain("<li>G</li><li>D</li><li>A</li>");
-    expect(result).toContain("<ul>Correct answers: G, D, A</ul>");
+    expect(result).toContain("<ol>Correct answers: <li>G</li><li>D</li><li>A</li></ol>");
   });
 
   test("should handle incorrect student answers", () => {
@@ -89,7 +90,7 @@ describe("checkAndFormatKeySigIdentifyAnswers", () => {
 
     expect(result).toContain("<b>2/3</b>");
     expect(result).toContain("<li>G</li><li><b>C</b></li><li>A</li>");
-    expect(result).toContain("<ul>Correct answers: G, D, A</ul>");
+    expect(result).toContain("<ol>Correct answers: <li>G</li><li>D</li><li>A</li></ol>");
   });
 });
 
@@ -109,7 +110,9 @@ describe("checkAndFormatChordIdentifyAnswers", () => {
 
     expect(result).toContain("<b>3/3</b>");
     expect(result).toContain("<li>Cmaj7</li><li>Dm7</li><li>G7</li>");
-    expect(result).toContain("<ul>Correct answers: Cmaj7, Dm7, G7</ul>");
+    expect(result).toContain(
+      "<ol>Correct answers: <li>Cmaj7</li><li>Dm7</li><li>G7</li></ol>"
+    );
   });
 
   test("should handle incorrect student answers", () => {
@@ -129,7 +132,9 @@ describe("checkAndFormatChordIdentifyAnswers", () => {
     expect(result).toContain(
       "<li>Cmaj7</li><li><b>D7</b></li><li><b>Gmaj7</b></li>"
     );
-    expect(result).toContain("<ul>Correct answers: Cmaj7, Dm7, G7</ul>");
+    expect(result).toContain(
+      "<ol>Correct answers: <li>Cmaj7</li><li>Dm7</li><li>G7</li></ol>"
+    );
   });
 });
 
@@ -221,7 +226,9 @@ describe("checkAndFormatChordAnswers", () => {
 
     expect(result).toContain("<b>2/2</b>");
     expect(result).toContain("<li>C, E, G</li><li>D, F, A</li>");
-    expect(result).toContain("<ol>Correct answers: C, E, G, D, F, A</ol>");
+    expect(result).toContain(
+      "<ol>Correct answers:<li>C, E, G</li><li>D, F, A</li></ol>"
+    );
   });
 
   test("should handle incorrect student answers", () => {
@@ -240,6 +247,8 @@ describe("checkAndFormatChordAnswers", () => {
 
     expect(result).toContain("<b>1/2</b>");
     expect(result).toContain("<li>C, E, G</li><li><b>D, F#, A</b></li>");
-    expect(result).toContain("<ol>Correct answers: C, E, G, D, F, A</ol>");
+    expect(result).toContain(
+      "<ol>Correct answers:<li>C, E, G</li><li>D, F, A</li></ol>"
+    );
   });
 });

--- a/app/lib/__tests__/calculateAnswers.test.ts
+++ b/app/lib/__tests__/calculateAnswers.test.ts
@@ -180,6 +180,28 @@ describe("checkAndFormatArrOfArrsAnswers", () => {
       "<ol>Correct answers:<li>C, E, G</li><li>D, F, A</li></ol>"
     );
   });
+
+  test("should mark missing notes as incorrect", () => {
+    const userAnswers = [
+      ["Bb", "Eb", "Ab"],
+      ["F#", "C#", "G#", "D#", "A#", "E#"],
+    ];
+    const correctAnswers = [
+      ["Bb", "Eb", "Ab", "Db", "Gb"],
+      ["F#", "C#", "G#", "D#", "A#", "E#"],
+    ];
+    const questionType = "Key Signature Notation";
+
+    const result = checkAndFormatArrOfArrsAnswers(
+      userAnswers,
+      correctAnswers,
+      questionType
+    );
+
+    expect(result).toContain("<b>1/2</b>");
+    expect(result).toContain("<b>(Missing Db)</b>");
+    expect(result).toContain("<b>(Missing Gb)</b>");
+  });
 });
 
 describe("checkAndFormatChordAnswers", () => {

--- a/app/lib/calculateAnswers.ts
+++ b/app/lib/calculateAnswers.ts
@@ -143,23 +143,37 @@ export const checkAndFormatArrOfArrsAnswers = (
       actualStudentAnswers += `<li><b>(No answer provided)</b></li>`;
     } else {
       let isCorrect = true;
-      let formattedUserAnswer = userAnswers[i]
-        .map((answer, j) => {
-          const userNote = answer.split("/")[0];
-          const correctNote = correctAnswers[i][j];
+      const currentUserAnswer = userAnswers[i];
+      const currentCorrectAnswer = correctAnswers[i];
+      const maxNotesLength = Math.max(
+        currentUserAnswer.length,
+        currentCorrectAnswer.length
+      );
 
-          // Normalize note name for case-insensitive comparison
-          // This handles the special B/b case and any other case differences
+      const formattedUserAnswer = Array.from(
+        { length: maxNotesLength },
+        (_, j) => {
+          const userAnswer = currentUserAnswer[j];
+          const userNote = userAnswer?.split("/")[0];
+          const correctNote = currentCorrectAnswer[j];
+
+          // Normalize note names for case-insensitive comparison.
           const normalizedUserNote = userNote?.toLowerCase() || "";
           const normalizedCorrectNote = correctNote?.toLowerCase() || "";
+          const isMatch = normalizedUserNote === normalizedCorrectNote;
 
-          if (normalizedUserNote !== normalizedCorrectNote) {
+          if (!isMatch) {
             isCorrect = false;
-            return `<b>${userNote}</b>`;
           }
-          return userNote;
-        })
-        .join(", ");
+
+          if (userNote) {
+            return isMatch ? userNote : `<b>${userNote}</b>`;
+          }
+
+          // Required accidental/note is missing from student response.
+          return `<b>(Missing ${correctNote})</b>`;
+        }
+      ).join(", ");
 
       if (isCorrect) score++;
       actualStudentAnswers += `<li>${formattedUserAnswer}</li>`;


### PR DESCRIPTION
## Summary
- Fixed a grading bug in Key Signatures Notate where partial accidental answers could be marked correct.
- Updated `checkAndFormatArrOfArrsAnswers` to require an exact note/accidental match (same notes in the same positions, with no missing or extra entries).
- Added a regression test for missing accidentals and refreshes outdated `calculateAnswers` test expectations to match current HTML output format.
- Changed organization name to Lydian Lab Music

## Why
- The section should only award credit for complete, exact key-signature notation answers (e.g., `Bb, Eb, Ab, Db, Gb` is correct; `Bb, Eb, Ab` is not).